### PR TITLE
feat(tools_api): add upsert support to create_tool_from_schema

### DIFF
--- a/.github/workflows/dblinter.yml
+++ b/.github/workflows/dblinter.yml
@@ -22,17 +22,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Java
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
           java-version: "21"
+          distribution: "oracle"
 
       - name: Download dbLinter CLI
         run: |
-          curl -L -o dblinter.zip https://github.com/Grisselbav/dbLinter/releases/download/cli-v1.0.0/dblinter-1.0.0.zip
+          curl -L -o dblinter.zip https://github.com/Grisselbav/dbLinter/releases/download/v1.3.0/dblinter-1.3.0.zip
           unzip dblinter.zip
-          chmod +x dblinter-1.0.0/dblinter
+          mv dblinter-* dblinter
+          chmod +x dblinter/dblinter
 
       - name: Create .dblinter directory
         run: mkdir -p .dblinter
@@ -42,7 +43,7 @@ jobs:
           cat > .dblinter/check.properties << EOF
           workspace=${{ github.workspace }}
           repoUrl=https://api.dblinter.app/
-          tenantName=Free-1001-CUGF-2426
+          tenantName=UNITEDCODES
           userName=${{ secrets.DBLINTER_USERNAME }}
           accessToken=${{ secrets.DBLINTER_ACCESS_TOKEN }}
           configName=Default
@@ -56,7 +57,7 @@ jobs:
 
       - name: Run dbLinter
         run: |
-          java -jar dblinter-1.0.0/dblinter-cli.jar --options=.dblinter/check.properties check
+          java -jar dblinter/dblinter-cli.jar --options=.dblinter/check.properties check
 
       - name: Output dbLinter annotations
         run: cat .dblinter/check.github.txt

--- a/docs/src/components/AlertBanner.astro
+++ b/docs/src/components/AlertBanner.astro
@@ -5,7 +5,7 @@
 <div id="workshop-banner" class="alert-banner" style="display: none;">
   <div class="alert-banner-content">
     <span class="alert-banner-text">
-      🎓 <strong>UC AI Workshop in February!</strong> From LLM basics to powerful PL/SQL Agents. 
+      🎓 <strong>UC AI Workshop in April/May!</strong> From LLM basics to powerful PL/SQL Agents. 
       <a href="https://www.united-codes.com/ai/training" target="_blank" rel="noopener">Learn more →</a>
     </span>
     <button id="dismiss-banner" class="alert-banner-dismiss" aria-label="Dismiss banner">
@@ -19,7 +19,7 @@
 
 <script is:inline>
   (function() {
-    var STORAGE_KEY = 'uc-ai-workshop-banner-dismissed';
+    var STORAGE_KEY = 'uc-ai-workshop-banner-dismissed-apr-26';
 
     function initBanner() {
       var banner = document.getElementById('workshop-banner');

--- a/docs/src/content/docs/other/faq.md
+++ b/docs/src/content/docs/other/faq.md
@@ -15,11 +15,14 @@ UC AI supports Oracle Database 12.2 or later. You don't need Oracle 23ai - the f
 
 ## Which AI providers are supported?
 
-Currently, UC AI supports four major AI providers:
+Currently, UC AI supports seven AI providers:
 - **OpenAI** (GPT models)
-- **Anthropic** (Claude models) 
+- **Anthropic** (Claude models)
 - **Google** (Gemini models)
+- **OCI** (Oracle Cloud Infrastructure Generative AI)
 - **Ollama** (Open source models like Llama, Mistral, Qwen, etc.)
+- **xAI** (Grok models)
+- **OpenRouter** (Unified access to models from many providers)
 
 The framework is designed to make it easy to switch between providers without changing your code.
 
@@ -40,3 +43,33 @@ Yes! One of UC AI's key features is function calling (tools). You can register d
 5. Start using `uc_ai.generate_text()` in your PL/SQL code
 
 Check out the [Installation Guide](/products/uc-ai/docs/guides/installation/) for detailed steps.
+
+## What if UC AI doesn't have a constant for a new model? {#custom-model-strings}
+
+AI providers frequently release new models. If UC AI doesn't yet offer a constant for a model, you can simply pass the model name as a string directly to the `p_model` parameter:
+
+```sql
+declare
+  l_result json_object_t;
+begin
+  l_result := uc_ai.generate_text(
+    p_user_prompt => 'What is Oracle APEX?',
+    p_provider => uc_ai.c_provider_openai,
+    p_model => 'gpt-5.4'
+  );
+end;
+```
+
+The `p_model` parameter accepts any `varchar2` value, so you are not limited to the pre-defined constants. The constants are provided for convenience and to avoid typos, but any valid model identifier string that the provider accepts will work.
+
+## Why doesn't UC AI have a table of providers and models instead of constants? {#no-model-table}
+
+This is a deliberate design decision. UC AI provides package constants for common models as a convenience, but intentionally does not maintain a configuration table of providers and models. Here's why:
+
+- **You can use any model immediately** — as explained [above](#custom-model-strings), you can pass any model name as a string to `p_model` without waiting for a UC AI update.
+- **The model landscape changes too fast** — new models are released constantly. A configuration table would always be outdated unless maintained by the user anyway.
+- **Some providers have hundreds of models** — OpenRouter alone supports over 600 models. Maintaining a complete list is not feasible.
+- **Override scenarios make it impractical** — OpenAI-compatible providers like DeepSeek work through base URL overrides without first-class support. There is no way to provide constants for all possible override combinations.
+- **Organizations want their own governance** — most teams want to restrict which providers and models are available to their users. This kind of policy logic is better owned by your application.
+
+The focus of UC AI is on making LLMs work reliably across providers. If you need a model catalog or approval workflow, we recommend implementing that in your own application layer.

--- a/docs/src/content/docs/providers/anthropic.mdx
+++ b/docs/src/content/docs/providers/anthropic.mdx
@@ -58,6 +58,10 @@ The UC AI Anthropic package provides constants for these Claude models:
 - `uc_ai_anthropic.c_model_claude_3_5_haiku`
 - `uc_ai_anthropic.c_model_claude_3_opus`
 
+:::tip
+If a new model is not yet available as a constant, you can pass the model name directly as a string. See the [FAQ](/products/uc-ai/docs/other/faq/#custom-model-strings) for details.
+:::
+
 ## Usage Examples
 
 ### Basic Text Generation

--- a/docs/src/content/docs/providers/google.mdx
+++ b/docs/src/content/docs/providers/google.mdx
@@ -68,6 +68,10 @@ Second generation Gemini models:
 
 See [Google's model documentation](https://ai.google.dev/gemini-api/docs/models/gemini) for detailed model information and [Artificial Analysis](https://artificialanalysis.ai/providers/google) for a comparison of intelligence, speed, and price.
 
+:::tip
+If a new model is not yet available as a constant, you can pass the model name directly as a string. See the [FAQ](/products/uc-ai/docs/other/faq/#custom-model-strings) for details.
+:::
+
 ## Usage Examples
 
 ### Basic Text Generation

--- a/docs/src/content/docs/providers/oci.mdx
+++ b/docs/src/content/docs/providers/oci.mdx
@@ -50,6 +50,10 @@ Refer to [this list of available models](https://docs.oracle.com/en-us/iaas/Cont
 
 Coming soon...
 
+:::tip
+If a new model is not yet available as a constant, you can pass the model name directly as a string. See the [FAQ](/products/uc-ai/docs/other/faq/#custom-model-strings) for details.
+:::
+
 ## Usage Examples
 
 ### Basic Text Generation

--- a/docs/src/content/docs/providers/openai.mdx
+++ b/docs/src/content/docs/providers/openai.mdx
@@ -85,6 +85,10 @@ Reasoning models have the prefix `o` and are designed to think longer and harder
 
 See [OpenAI's pricing page](https://platform.openai.com/docs/pricing) for the latest model information and costs. Also see [Artificial Analysis](https://artificialanalysis.ai/providers/openai) for a comparison of intelligence, speed, and price.
 
+:::tip
+If a new model is not yet available as a constant, you can pass the model name directly as a string. See the [FAQ](/products/uc-ai/docs/other/faq/#custom-model-strings) for details.
+:::
+
 ## Usage Examples
 
 ### Basic Text Generation

--- a/docs/src/content/docs/providers/xai.mdx
+++ b/docs/src/content/docs/providers/xai.mdx
@@ -67,6 +67,10 @@ Previous generation models:
 
 See [xAI's models documentation](https://docs.x.ai/docs/models) for the latest model information and capabilities.
 
+:::tip
+If a new model is not yet available as a constant, you can pass the model name directly as a string. See the [FAQ](/products/uc-ai/docs/other/faq/#custom-model-strings) for details.
+:::
+
 ## Usage Examples
 
 ### Basic Text Generation

--- a/scripts/generate_install_script_complete.sh
+++ b/scripts/generate_install_script_complete.sh
@@ -26,6 +26,25 @@ add_file_content() {
     local output_file="${3:-$OUTPUT_FILE}"
     
     if [ -f "$file_path" ]; then
+        # Check for direct logger. calls in PL/SQL files (only uc_ai_logger may reference logger directly)
+        local basename_file
+        basename_file=$(basename "$file_path")
+        if [[ "$basename_file" == *.pks || "$basename_file" == *.pkb || "$basename_file" == *.sql ]] \
+            && [[ "$basename_file" != uc_ai_logger.* ]] \
+            && [[ "$file_path" != */dependencies/* ]]; then
+            # Find lines with logger. that are not uc_ai_logger. and not comments
+            local bad_lines
+            bad_lines=$(grep -in 'logger\.' "$file_path" | grep -iv 'uc_ai_logger\.' | grep -v '^\s*--' || true)
+            if [ -n "$bad_lines" ]; then
+                echo ""
+                echo "ERROR: Direct 'logger.' calls found in $file_path"
+                echo "Only the uc_ai_logger package may reference logger directly."
+                echo "Use uc_ai_logger instead. Offending lines:"
+                echo "$bad_lines"
+                exit 1
+            fi
+        fi
+
         echo "" >> "$output_file"
         echo "/* ====================================================" >> "$output_file"
         echo "   $description" >> "$output_file"

--- a/scripts/package_utils.sh
+++ b/scripts/package_utils.sh
@@ -16,6 +16,7 @@ declare -a API_PACKAGES=(
     "uc_ai_message_api"
     "uc_ai_structured_output"
     "uc_ai_logger"
+    "uc_ai_error"
     "uc_ai_toon"
     "uc_ai_agents_api"
     "uc_ai_agent_exec_api"
@@ -77,6 +78,9 @@ get_package_description() {
             ;;
         "uc_ai_structured_output")
             echo "Structured Output Package"
+            ;;
+        "uc_ai_error")
+            echo "Error Handling Package"
             ;;
         "uc_ai_anthropic")
             echo "Anthropic AI Provider Package"

--- a/src/packages/uc_ai.pkb
+++ b/src/packages/uc_ai.pkb
@@ -172,6 +172,8 @@ create or replace package body uc_ai as
   procedure reset_globals
   as
   begin
+    -- @dblinter ignore(g-2135)
+
     -- Reset uc_ai global variables
     g_base_url := null;
     g_enable_reasoning := false;

--- a/src/packages/uc_ai.pkb
+++ b/src/packages/uc_ai.pkb
@@ -11,8 +11,6 @@ create or replace package body uc_ai as
   , p_response_json_schema  in json_object_t default null
   ) return json_object_t
   as
-    e_unknown_provider exception;
-    
     l_result json_object_t;
   begin
     case p_provider
@@ -46,7 +44,11 @@ create or replace package body uc_ai as
         );
       when c_provider_oci then
         if p_response_json_schema is not null then
-          raise_application_error(-20001, 'Provider ' || p_provider || ' does not support structured output');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_structured_unsupported
+          , p_scope      => c_scope_prefix || 'generate_text'
+          , p0           => p_provider
+          );
         else
           l_result := uc_ai_oci.generate_text(
             p_messages       => p_messages
@@ -75,31 +77,15 @@ create or replace package body uc_ai as
         , p_schema         => p_response_json_schema
         );
       else
-        raise e_unknown_provider;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_unknown_provider
+        , p_scope      => c_scope_prefix || 'generate_text'
+        , p0           => p_provider
+        );
     end case;
-   
-  
+
+
     return l_result;
-  exception
-    when e_unknown_provider then
-      raise_application_error(-20001, 'Unknown AI provider: ' || p_provider);
-    when e_max_calls_exceeded then
-      raise_application_error(-20301, 'Maximum tool calls exceeded');
-    when e_error_response then
-      raise_application_error(-20302, 'Error response from AI provider. Check logs for details');
-    when e_unhandled_format then
-      raise_application_error(-20303, 'Unhandled message format encountered. Please check the message structure and logs.');
-    when e_format_processing_error then
-      raise_application_error(-20304, 'Error processing message format. Please check the logs for details.');
-    when others then
-      uc_ai_logger.log_error(
-        'Unhandled exception in uc_ai.generate_text',
-        c_scope_prefix || 'generate_text',
-        sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace
-      );
-
-      raise;
-
   end generate_text;
 
   function generate_text (
@@ -140,8 +126,6 @@ create or replace package body uc_ai as
   , p_model in model_type
   ) return json_array_t
   as
-    e_unknown_provider exception;
-    
     l_result json_array_t;
   begin
     case p_provider
@@ -174,22 +158,15 @@ create or replace package body uc_ai as
         , p_model => p_model
         );
       else
-        raise e_unknown_provider;
-      
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_unknown_provider
+        , p_scope      => c_scope_prefix || 'generate_embeddings'
+        , p0           => p_provider
+        );
+
     end case;
 
     return l_result;
-  exception
-    when e_unknown_provider then
-      raise_application_error(-20001, 'Unknown AI provider: ' || p_provider);
-    when others then
-      uc_ai_logger.log_error(
-        'Unhandled exception in uc_ai.generate_embeddings',
-        c_scope_prefix || 'generate_embeddings',
-        sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace
-      );
-
-      raise;
   end generate_embeddings;
 
   procedure reset_globals

--- a/src/packages/uc_ai.pks
+++ b/src/packages/uc_ai.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai as
+create or replace package uc_ai 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_agent_exec_api.pkb
+++ b/src/packages/uc_ai_agent_exec_api.pkb
@@ -381,8 +381,11 @@ create or replace package body uc_ai_agent_exec_api as
         return execute_sequential_workflow(p_agent, p_input_params, p_session_id, p_exec_id);
         
       else
-        uc_ai_logger.log_error('Unknown workflow type: ' || l_workflow_type, l_scope);
-        raise_application_error(-20011, 'Unknown workflow type: ' || l_workflow_type);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_unknown_workflow_type
+        , p_scope      => l_scope
+        , p0           => l_workflow_type
+        );
     end case;
   exception
     when others then
@@ -413,8 +416,12 @@ create or replace package body uc_ai_agent_exec_api as
       l_agent := uc_ai_agents_api.get_agent(p_agent_code);
     exception
       when others then
-        uc_ai_logger.log_error('Error retrieving agent for tool registration: ' || p_agent_code, l_scope, sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace);
-        raise_application_error(-20012, 'Error retrieving agent for tool registration: ' || p_agent_code);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_agent_retrieval
+        , p_scope      => l_scope
+        , p0           => p_agent_code
+        , p_extra      => sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace
+        );
     end;
     
     -- Create function call that executes the agent
@@ -911,8 +918,11 @@ end;!';
           end loop find_participant_loop;
 
           if l_participant is null then
-            uc_ai_logger.log_error('Next speaker agent code "' || l_next_speaker.get_string('agent_code') || '" not found among participants, ending conversation', l_scope);
-            raise_application_error(-20013, 'Next speaker agent code "' || l_next_speaker.get_string('agent_code') || '" not found among participants');
+            uc_ai_error.raise_error(
+              p_error_code => uc_ai_error.c_err_speaker_not_found
+            , p_scope      => l_scope
+            , p0           => l_next_speaker.get_string('agent_code')
+            );
           end if;
 
           l_current_state.put('agent_description', l_agent_descr_map.get_string(l_participant.get_string('agent_code')));
@@ -967,8 +977,11 @@ end;!';
         l_return.put('completed', true);
         l_return.put('final_message', l_mod_result.get_string('final_message'));
       else
-        uc_ai_logger.log_error('Unknown conversation mode: ' || l_mode, l_scope);
-        raise_application_error(-20012, 'Unknown conversation mode: ' || l_mode);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_unknown_conv_mode
+        , p_scope      => l_scope
+        , p0           => l_mode
+        );
     end case;
     
     -- conversation_complete
@@ -995,7 +1008,10 @@ end;!';
          fetch first 1 row only;
       exception
         when no_data_found then
-          raise_application_error(-20020, 'Cannot create APEX session: no applications found. In order to use UC AI Agents features the DB schema must have an APEX Workspace with at least one application. This is required as UC AI uses APEX util functions that unfortunately depend on an active APEX session.');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_apex_session
+          , p_scope      => gc_scope_prefix || 'create_apex_session_if_needed'
+          );
       end;
 
       apex_session.create_session(

--- a/src/packages/uc_ai_agent_exec_api.pks
+++ b/src/packages/uc_ai_agent_exec_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_agent_exec_api as
+create or replace package uc_ai_agent_exec_api 
+  authid definer
+as
   /*
    * UC AI Agent Execution API
    * 

--- a/src/packages/uc_ai_agent_workflow_api.pkb
+++ b/src/packages/uc_ai_agent_workflow_api.pkb
@@ -109,8 +109,13 @@ create or replace package body uc_ai_agent_workflow_api as
           );
         exception
           when others then
-            uc_ai_logger.log_error('Error evaluating PL/SQL expression for input mapping key ' || l_key || ': ' || sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace, l_scope, l_resolved);
-            raise_application_error(-20022, 'Error evaluating PL/SQL expression for input mapping key ' || l_key || ': ' || l_resolved || ' - ' || sqlerrm);
+            uc_ai_error.raise_error(
+              p_error_code => uc_ai_error.c_err_input_mapping_eval
+            , p_scope      => l_scope
+            , p0           => l_key
+            , p1           => sqlerrm
+            , p_extra      => l_resolved || chr(10) || sys.dbms_utility.format_error_backtrace
+            );
         end;
       end if;
 
@@ -167,8 +172,13 @@ create or replace package body uc_ai_agent_workflow_api as
       return l_resolved;
     exception
       when others then
-        uc_ai_logger.log_error('Error evaluating PL/SQL expression for final_message: ' || sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace, l_scope, l_tmp);
-        raise_application_error(-20023, 'Error evaluating PL/SQL expression for final_message: ' || l_tmp || ' - ' || sqlerrm );
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_final_message_eval
+        , p_scope      => l_scope
+        , p0           => l_tmp
+        , p1           => sqlerrm
+        , p_extra      => sys.dbms_utility.format_error_backtrace
+        );
     end;
   end evaluate_final_message;
 
@@ -200,8 +210,13 @@ create or replace package body uc_ai_agent_workflow_api as
       );
     exception
       when others then
-        uc_ai_logger.log_error('Error evaluating condition expression: ' || sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace, l_scope, l_expression);
-        raise_application_error(-20021, 'Error evaluating condition expression: ' || l_expression || ' - ' || sqlerrm);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_condition_eval
+        , p_scope      => l_scope
+        , p0           => l_expression
+        , p1           => sqlerrm
+        , p_extra      => sys.dbms_utility.format_error_backtrace
+        );
     end;
 
 
@@ -230,8 +245,11 @@ create or replace package body uc_ai_agent_workflow_api as
     if p_step.has('output_key') then
       l_output_key := p_step.get_string('output_key');
     else
-      uc_ai_logger.log_error('Step definition missing output_key', l_scope, p_step.to_clob);
-      raise_application_error(-20020, 'Step definition missing output_key');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_missing_output_key
+      , p_scope      => l_scope
+      , p_extra      => p_step.to_clob
+      );
     end if;
     
     -- Update _steps in workflow state

--- a/src/packages/uc_ai_agent_workflow_api.pks
+++ b/src/packages/uc_ai_agent_workflow_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_agent_workflow_api as
+create or replace package uc_ai_agent_workflow_api 
+  authid definer
+as
   /*
    * UC AI Agent Workflow API
    * 

--- a/src/packages/uc_ai_agents_api.pkb
+++ b/src/packages/uc_ai_agents_api.pkb
@@ -214,45 +214,73 @@ create or replace package body uc_ai_agents_api as
     case p_agent_type
       when c_type_profile then
         if p_prompt_profile_code is null then
-          uc_ai_logger.log_error('Profile agent requires prompt_profile_code', l_scope);
-          raise_application_error(-20001, 'Profile agent requires prompt_profile_code');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_missing_config
+          , p_scope      => l_scope
+          , p0           => 'Profile agent'
+          , p1           => 'prompt_profile_code'
+          );
         end if;
         
       when c_type_workflow then
         if p_workflow_definition is null then
-          uc_ai_logger.log_error('Workflow agent requires workflow_definition', l_scope);
-          raise_application_error(-20001, 'Workflow agent requires workflow_definition');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_missing_config
+          , p_scope      => l_scope
+          , p0           => 'Workflow agent'
+          , p1           => 'workflow_definition'
+          );
         end if;
         declare
           l_validation t_validation_result;
         begin
           l_validation := validate_workflow_definition(p_workflow_definition);
           if not l_validation.is_valid then
-            raise_application_error(-20001, 'Invalid workflow definition: ' || l_validation.error_reason);
+            uc_ai_error.raise_error(
+              p_error_code => uc_ai_error.c_err_invalid_config
+            , p_scope      => l_scope
+            , p0           => 'workflow definition'
+            , p1           => l_validation.error_reason
+            );
           end if;
         end;
         
       when c_type_orchestrator then
         if p_orchestration_config is null then
-          uc_ai_logger.log_error('Orchestrator agent requires orchestration_config', l_scope);
-          raise_application_error(-20001, 'Orchestrator agent requires orchestration_config');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_missing_config
+          , p_scope      => l_scope
+          , p0           => 'Orchestrator agent'
+          , p1           => 'orchestration_config'
+          );
         end if;
         
       when c_type_handoff then
         if p_orchestration_config is null then
-          uc_ai_logger.log_error('Handoff agent requires orchestration_config', l_scope);
-          raise_application_error(-20001, 'Handoff agent requires orchestration_config');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_missing_config
+          , p_scope      => l_scope
+          , p0           => 'Handoff agent'
+          , p1           => 'orchestration_config'
+          );
         end if;
         
       when c_type_conversation then
         if p_orchestration_config is null then
-          uc_ai_logger.log_error('Conversation agent requires orchestration_config', l_scope);
-          raise_application_error(-20001, 'Conversation agent requires orchestration_config');
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_missing_config
+          , p_scope      => l_scope
+          , p0           => 'Conversation agent'
+          , p1           => 'orchestration_config'
+          );
         end if;
         
       else
-        uc_ai_logger.log_error('Invalid agent_type: ' || p_agent_type, l_scope);
-        raise_application_error(-20001, 'Invalid agent_type: ' || p_agent_type);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_unknown_agent_type
+        , p_scope      => l_scope
+        , p0           => p_agent_type
+        );
     end case;
     
     -- Validate agent references in configs
@@ -261,10 +289,15 @@ create or replace package body uc_ai_agents_api as
     begin
       l_validation := validate_agent_references(p_workflow_definition, p_orchestration_config);
       if not l_validation.is_valid then
-        raise_application_error(-20001, 'Invalid agent references in configuration: ' || l_validation.error_reason);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_invalid_config
+        , p_scope      => l_scope
+        , p0           => 'agent references in configuration'
+        , p1           => l_validation.error_reason
+        );
       end if;
     end;
-    
+
     insert into uc_ai_agents (
       code,
       version,
@@ -332,7 +365,12 @@ create or replace package body uc_ai_agents_api as
       begin
         l_validation := validate_agent_references(p_workflow_definition, p_orchestration_config);
         if not l_validation.is_valid then
-          raise_application_error(-20001, 'Invalid agent references in configuration: ' || l_validation.error_reason);
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_invalid_config
+          , p_scope      => l_scope
+          , p0           => 'agent references in configuration'
+          , p1           => l_validation.error_reason
+          );
         end if;
       end;
     end if;
@@ -351,8 +389,12 @@ create or replace package body uc_ai_agents_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Agent not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Agent not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_id
+      );
     end if;
   exception
     when others then
@@ -383,13 +425,21 @@ create or replace package body uc_ai_agents_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Agent not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Agent not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_id
+      );
     end if;
   exception
     when no_data_found then
-      uc_ai_logger.log_error('Agent not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Agent not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_id
+      );
     when others then
       uc_ai_logger.log_error('Error deleting agent', l_scope, sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace);
       raise;
@@ -414,8 +464,12 @@ create or replace package body uc_ai_agents_api as
       and version = p_version;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Agent not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-      raise_application_error(-20001, 'Agent not found with code: ' || p_code || ', version: ' || p_version);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_code || ' v' || p_version
+      );
     end if;
   exception
     when others then
@@ -435,8 +489,12 @@ create or replace package body uc_ai_agents_api as
     l_scope uc_ai_logger.scope := gc_scope_prefix || 'change_status';
   begin
     if p_status not in (c_status_draft, c_status_active, c_status_archived) then
-      uc_ai_logger.log_error('Invalid status value: ' || p_status, l_scope);
-      raise_application_error(-20002, 'Invalid status. Must be: draft, active, or archived');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_invalid_status
+      , p_scope      => l_scope
+      , p0           => p_status
+      , p1           => 'draft, active, archived'
+      );
     end if;
 
     update uc_ai_agents
@@ -444,8 +502,12 @@ create or replace package body uc_ai_agents_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Agent not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Agent not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_id
+      );
     end if;
   exception
     when others then
@@ -466,8 +528,12 @@ create or replace package body uc_ai_agents_api as
     l_scope uc_ai_logger.scope := gc_scope_prefix || 'change_status';
   begin
     if p_status not in (c_status_draft, c_status_active, c_status_archived) then
-      uc_ai_logger.log_error('Invalid status value: ' || p_status, l_scope);
-      raise_application_error(-20002, 'Invalid status. Must be: draft, active, or archived');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_invalid_status
+      , p_scope      => l_scope
+      , p0           => p_status
+      , p1           => 'draft, active, archived'
+      );
     end if;
 
     update uc_ai_agents
@@ -476,8 +542,12 @@ create or replace package body uc_ai_agents_api as
       and version = p_version;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Agent not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-      raise_application_error(-20001, 'Agent not found with code: ' || p_code || ', version: ' || p_version);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_code || ' v' || p_version
+      );
     end if;
   exception
     when others then
@@ -509,8 +579,12 @@ create or replace package body uc_ai_agents_api as
         and version = p_source_version;
     exception
       when no_data_found then
-        uc_ai_logger.log_error('Source agent not found with code: ' || p_code || ', version: ' || p_source_version, l_scope);
-        raise_application_error(-20001, 'Source agent not found with code: ' || p_code || ', version: ' || p_source_version);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Source agent'
+        , p1           => p_code || ' v' || p_source_version
+        );
     end;
 
     -- Determine new version number
@@ -583,8 +657,12 @@ create or replace package body uc_ai_agents_api as
     return l_agent;
   exception
     when no_data_found then
-      uc_ai_logger.log_error('Agent not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Agent not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Agent'
+      , p1           => p_id
+      );
     when others then
       uc_ai_logger.log_error('Error getting agent', l_scope, sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace);
       raise;
@@ -623,11 +701,19 @@ create or replace package body uc_ai_agents_api as
   exception
     when no_data_found then
       if p_version is null then
-        uc_ai_logger.log_error('No active agent found with code: ' || p_code, l_scope);
-        raise_application_error(-20001, 'No active agent found with code: ' || p_code);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Active agent'
+        , p1           => p_code
+        );
       else
-        uc_ai_logger.log_error('Agent not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-        raise_application_error(-20001, 'Agent not found with code: ' || p_code || ', version: ' || p_version);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Agent'
+        , p1           => p_code || ' v' || p_version
+        );
       end if;
     when others then
       uc_ai_logger.log_error('Error getting agent', l_scope, sqlerrm || ' - Backtrace: ' || sys.dbms_utility.format_error_backtrace);
@@ -712,8 +798,12 @@ create or replace package body uc_ai_agents_api as
        or (orchestration_config is not null and regexp_like(orchestration_config, l_search_expr));
     
     if l_ref_count > 0 then
-      uc_ai_logger.log_error('Agent is referenced by ' || l_ref_count || ' other agent(s): ' || p_agent_code, l_scope);
-      raise_application_error(-20003, 'Cannot delete agent "' || p_agent_code || '": it is referenced by ' || l_ref_count || ' other agent(s)');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_has_references
+      , p_scope      => l_scope
+      , p0           => p_agent_code
+      , p1           => l_ref_count
+      );
     end if;
   exception
     when others then
@@ -1004,11 +1094,14 @@ create or replace package body uc_ai_agents_api as
     p_response_schema  in json_object_t default null
   ) return json_object_t
   as
-    l_scope      uc_ai_logger.scope := gc_scope_prefix || 'execute_agent';
-    l_agent      uc_ai_agents%rowtype;
-    l_exec_id    uc_ai_agent_executions.id%type;
-    l_session_id varchar2(255 char);
-    l_result     json_object_t;
+    l_scope         uc_ai_logger.scope := gc_scope_prefix || 'execute_agent';
+    l_agent         uc_ai_agents%rowtype;
+    l_exec_id       uc_ai_agent_executions.id%type;
+    l_session_id    varchar2(255 char);
+    l_result        json_object_t;
+    l_usage         json_object_t;
+    l_input_tokens  number := 0;
+    l_output_tokens number := 0;
   begin
     uc_ai_logger.log('Executing agent: ' || p_agent_code, l_scope);
 
@@ -1019,8 +1112,12 @@ create or replace package body uc_ai_agents_api as
     
     -- Validate response_schema usage
     if p_response_schema is not null and l_agent.agent_type != c_type_profile then
-      uc_ai_logger.log_error('response_schema can only be used with profile agents, not: ' || l_agent.agent_type, l_scope);
-      raise_application_error(-20011, 'response_schema can only be used with profile agents');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_invalid_config
+      , p_scope      => l_scope
+      , p0           => 'response_schema'
+      , p1           => 'can only be used with profile agents, not ' || l_agent.agent_type
+      );
     end if;
     
     -- Generate session ID if not provided
@@ -1049,8 +1146,11 @@ create or replace package body uc_ai_agents_api as
           l_result := uc_ai_agent_exec_api.execute_conversation_agent(l_agent, p_input_parameters, l_session_id, l_exec_id);
           
         else
-          uc_ai_logger.log_error('Unknown agent type: ' || l_agent.agent_type, l_scope);
-          raise_application_error(-20010, 'Unknown agent type: ' || l_agent.agent_type);
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_unknown_agent_type
+          , p_scope      => l_scope
+          , p0           => l_agent.agent_type
+          );
       end case;
 
       l_result.put('execution_id', l_exec_id);
@@ -1060,12 +1160,30 @@ create or replace package body uc_ai_agents_api as
       l_result.put('status', c_exec_completed);
 
       uc_ai_logger.log('Agent execution completed: ' || p_agent_code, l_scope, l_result.to_clob);
-      
+
+      -- Extract token usage from result
+      if l_result.has('usage') then
+        -- Profile and orchestrator agents return generate_text() result with usage object
+        l_usage := l_result.get_object('usage');
+        l_input_tokens := nvl(l_usage.get_number('prompt_tokens'), 0);
+        l_output_tokens := nvl(l_usage.get_number('completion_tokens'), 0);
+      else
+        -- Workflow, handoff, and conversation agents have child executions — aggregate their tokens
+        select nvl(sum(total_input_tokens), 0),
+               nvl(sum(total_output_tokens), 0)
+          into l_input_tokens,
+               l_output_tokens
+          from uc_ai_agent_executions
+         where parent_execution_id = l_exec_id;
+      end if;
+
       -- Update execution as completed
       complete_execution(
-        p_exec_id       => l_exec_id,
-        p_status        => c_exec_completed,
-        p_output_result => l_result
+        p_exec_id        => l_exec_id,
+        p_status         => c_exec_completed,
+        p_output_result  => l_result,
+        p_input_tokens   => l_input_tokens,
+        p_output_tokens  => l_output_tokens
       );
       
     exception
@@ -1214,8 +1332,12 @@ create or replace package body uc_ai_agents_api as
     return l_result;
   exception
     when no_data_found then
-      uc_ai_logger.log_error('Execution not found with ID: ' || p_execution_id, l_scope);
-      raise_application_error(-20001, 'Execution not found with ID: ' || p_execution_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Execution'
+      , p1           => p_execution_id
+      );
     when others then
       uc_ai_logger.log_error('Error getting execution details', l_scope);
       raise;

--- a/src/packages/uc_ai_agents_api.pkb
+++ b/src/packages/uc_ai_agents_api.pkb
@@ -1059,7 +1059,7 @@ create or replace package body uc_ai_agents_api as
       l_result.put('session_id', l_session_id);
       l_result.put('status', c_exec_completed);
 
-      logger.log('Agent execution completed: ' || p_agent_code, l_scope, l_result.to_clob);
+      uc_ai_logger.log('Agent execution completed: ' || p_agent_code, l_scope, l_result.to_clob);
       
       -- Update execution as completed
       complete_execution(

--- a/src/packages/uc_ai_agents_api.pks
+++ b/src/packages/uc_ai_agents_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_agents_api as
+create or replace package uc_ai_agents_api 
+  authid definer
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_anthropic.pkb
+++ b/src/packages/uc_ai_anthropic.pkb
@@ -1,4 +1,4 @@
-create or replace package body uc_ai_anthropic as 
+create or replace package body uc_ai_anthropic as
 
   c_scope_prefix constant varchar2(31 char) := lower($$plsql_unit) || '.';
   c_api_url constant varchar2(255 char) := 'https://api.anthropic.com/v1';
@@ -148,15 +148,24 @@ create or replace package body uc_ai_anthropic as
                     l_file_block.put('source', json_object_t('{"type": "base64", "media_type": "' || l_mime_type || '", "data": "' || l_data || '"}'));
 
                   else
-                    uc_ai_logger.log_error('Unsupported file type: ' || l_mime_type, l_scope, l_content_item.stringify);
-                    raise uc_ai.e_unhandled_format;
+                    uc_ai_error.raise_error(
+                      p_error_code => uc_ai_error.c_err_unhandled_format
+                    , p_scope      => l_scope
+                    , p0           => 'file type'
+                    , p1           => l_mime_type
+                    , p_extra      => l_content_item.stringify
+                    );
                   end if;
                   
                   l_anthropic_content.append(l_file_block);
                 end;
               else
-                uc_ai_logger.log_error('Unknown content type in user message: ' || l_content_type, l_scope, l_content_item.stringify);
-                raise uc_ai.e_unhandled_format;
+                uc_ai_error.raise_error(
+                  p_error_code => uc_ai_error.c_err_unsupported_content
+                , p_scope      => l_scope
+                , p0           => l_content_type
+                , p_extra      => l_content_item.stringify
+                );
             end case;
           end loop user_content_loop;
           
@@ -288,14 +297,17 @@ create or replace package body uc_ai_anthropic as
     l_has_tool_use boolean := false;
   begin
     if g_tool_calls >= p_max_tool_calls then
-      uc_ai_logger.log_warn('Max calls reached', l_scope, 'Max calls: ' || g_tool_calls);
       pio_result.put('finish_reason', 'max_tool_calls_exceeded');
-      raise uc_ai.e_max_calls_exceeded;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_max_calls_exceeded
+      , p_scope      => l_scope
+      , p0           => to_char(p_max_tool_calls)
+      );
     end if;
 
     l_input_obj := p_input_obj;
     l_input_obj.put('messages', pio_messages);
-    
+
     -- Add system prompt if provided (Anthropic uses separate system field)
     if p_system_prompt is not null then
       l_input_obj.put('system', p_system_prompt);
@@ -328,9 +340,13 @@ create or replace package body uc_ai_anthropic as
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-      uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'anthropic'
+      , p1           => l_temp_obj.get_string('message')
+      , p_extra      => l_temp_obj.to_clob
+      );
     end if;
 
     -- Extract and accumulate usage information in global counters
@@ -462,8 +478,12 @@ create or replace package body uc_ai_anthropic as
               l_new_msg := get_text_content(l_content_prompt);
               l_normalized_messages.append(l_new_msg);
             else
-              uc_ai_logger.log_error('Unsupported content type in tool use: ' || l_content_prompt.get_string('type'), l_scope, l_content_prompt.to_clob);
-              raise_application_error(-20001, 'Unsupported content type: ' || l_content_prompt.get_string('type'));
+              uc_ai_error.raise_error(
+                p_error_code => uc_ai_error.c_err_unsupported_content
+              , p_scope      => l_scope
+              , p0           => l_content_prompt.get_string('type')
+              , p_extra      => l_content_prompt.to_clob
+              );
           end case;
         end loop tool_use_loop;
 
@@ -510,8 +530,12 @@ create or replace package body uc_ai_anthropic as
               l_content_msg := get_reasoning_content(l_content_prompt);
               l_content_array.append(l_content_msg);
             else
-              uc_ai_logger.log_error('Unknown content type: ' || l_content_type, l_scope, l_content_prompt.to_clob);
-              raise_application_error(-20001, 'Unsupported content type: ' || l_content_type);
+              uc_ai_error.raise_error(
+                p_error_code => uc_ai_error.c_err_unsupported_content
+              , p_scope      => l_scope
+              , p0           => l_content_type
+              , p_extra      => l_content_prompt.to_clob
+              );
           end case; 
 
           pio_messages.append(l_content_prompt);
@@ -638,7 +662,12 @@ create or replace package body uc_ai_anthropic as
     end if;
 
     if g_max_tokens < l_reasoning_tokens then
-      raise_application_error(-20001, 'Reasoning budget tokens (' || l_reasoning_tokens || ') exceed max tokens allowed (' || g_max_tokens || '). Set a higher max tokens value (uc_ai_anthropic.g_max_tokens).');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_reasoning_budget
+      , p_scope      => l_scope
+      , p0           => to_char(l_reasoning_tokens)
+      , p1           => to_char(g_max_tokens)
+      );
     end if;
 
     l_input_obj.put('max_tokens', g_max_tokens); -- Anthropic requires max_tokens

--- a/src/packages/uc_ai_anthropic.pkb
+++ b/src/packages/uc_ai_anthropic.pkb
@@ -336,7 +336,7 @@ create or replace package body uc_ai_anthropic as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    l_resp_json := json_object_t.parse(l_resp);
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Anthropic', l_scope);
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');

--- a/src/packages/uc_ai_anthropic.pkb
+++ b/src/packages/uc_ai_anthropic.pkb
@@ -474,8 +474,13 @@ create or replace package body uc_ai_anthropic as
               l_normalized_tool_results.append(l_new_msg);
             when 'text' then
               uc_ai_logger.log('Text content block found', l_scope, l_content_prompt.to_clob);
-   
+
               l_new_msg := get_text_content(l_content_prompt);
+              l_normalized_messages.append(l_new_msg);
+            when 'thinking' then
+              uc_ai_logger.log('Thinking content block found', l_scope, l_content_prompt.to_clob);
+
+              l_new_msg := get_reasoning_content(l_content_prompt);
               l_normalized_messages.append(l_new_msg);
             else
               uc_ai_error.raise_error(

--- a/src/packages/uc_ai_anthropic.pks
+++ b/src/packages/uc_ai_anthropic.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_anthropic as
+create or replace package uc_ai_anthropic 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_error.pkb
+++ b/src/packages/uc_ai_error.pkb
@@ -87,5 +87,29 @@ create or replace package body uc_ai_error as
     raise_application_error(p_error_code, l_msg);
   end raise_error;
 
+  function parse_json_response(
+    p_response in clob
+  , p_provider in varchar2
+  , p_scope    in varchar2
+  ) return json_object_t
+  is
+    l_status_code number;
+    l_preview     varchar2(500 char);
+  begin
+    return json_object_t.parse(p_response);
+  exception
+    when others then
+      l_status_code := apex_web_service.g_status_code;
+      l_preview := substr(p_response, 1, 500);
+
+      raise_error(
+        p_error_code => c_err_provider_response
+      , p_scope      => p_scope
+      , p0           => p_provider
+      , p1           => 'Status Code from provider: ' || l_status_code || ', Provider response: ' || l_preview
+      , p_extra      => p_response
+      );
+  end parse_json_response;
+
 end uc_ai_error;
 /

--- a/src/packages/uc_ai_error.pkb
+++ b/src/packages/uc_ai_error.pkb
@@ -1,0 +1,91 @@
+create or replace package body uc_ai_error as
+
+  -- @dblinter ignore(g-9108)
+
+  function get_default_message(
+    p_error_code in number
+  ) return varchar2
+  is
+  begin
+    return case p_error_code
+      -- Core / Provider
+      when c_err_max_calls_exceeded     then c_msg_max_calls_exceeded
+      when c_err_provider_response      then c_msg_provider_response
+      when c_err_unhandled_format       then c_msg_unhandled_format
+      when c_err_format_processing      then c_msg_format_processing
+      when c_err_model_not_found        then c_msg_model_not_found
+      when c_err_unknown_provider       then c_msg_unknown_provider
+      when c_err_structured_unsupported then c_msg_structured_unsupported
+      when c_err_reasoning_budget       then c_msg_reasoning_budget
+      -- Agent
+      when c_err_unknown_agent_type     then c_msg_unknown_agent_type
+      when c_err_unknown_workflow_type  then c_msg_unknown_workflow_type
+      when c_err_agent_retrieval        then c_msg_agent_retrieval
+      when c_err_speaker_not_found      then c_msg_speaker_not_found
+      when c_err_unknown_conv_mode      then c_msg_unknown_conv_mode
+      -- Workflow
+      when c_err_missing_output_key     then c_msg_missing_output_key
+      when c_err_condition_eval         then c_msg_condition_eval
+      when c_err_input_mapping_eval     then c_msg_input_mapping_eval
+      when c_err_final_message_eval     then c_msg_final_message_eval
+      when c_err_apex_session           then c_msg_apex_session
+      -- Validation
+      when c_err_not_found              then c_msg_not_found
+      when c_err_invalid_status         then c_msg_invalid_status
+      when c_err_missing_config         then c_msg_missing_config
+      when c_err_invalid_config         then c_msg_invalid_config
+      when c_err_has_references         then c_msg_has_references
+      when c_err_missing_placeholder    then c_msg_missing_placeholder
+      when c_err_unsupported_content    then c_msg_unsupported_content
+      else 'Error ' || p_error_code
+    end;
+  end get_default_message;
+
+  procedure raise_error(
+    p_error_code in number
+  , p_scope      in varchar2 default null
+  , p0           in varchar2 default null
+  , p1           in varchar2 default null
+  , p2           in varchar2 default null
+  , p3           in varchar2 default null
+  , p4           in varchar2 default null
+  , p5           in varchar2 default null
+  , p6           in varchar2 default null
+  , p7           in varchar2 default null
+  , p8           in varchar2 default null
+  , p9           in varchar2 default null
+  , p_message    in varchar2 default null
+  , p_extra      in clob     default null
+  , p_log        in boolean  default true
+  )
+  is
+    l_msg varchar2(2048 char);
+  begin
+    l_msg := apex_string.format(
+      p_message    => coalesce(p_message, get_default_message(p_error_code))
+    , p0           => p0
+    , p1           => p1
+    , p2           => p2
+    , p3           => p3
+    , p4           => p4
+    , p5           => p5
+    , p6           => p6
+    , p7           => p7
+    , p8           => p8
+    , p9           => p9
+    , p_max_length => 2048
+    );
+
+    if p_log then
+      uc_ai_logger.log_error(
+        p_text  => l_msg
+      , p_scope => p_scope
+      , p_extra => p_extra
+      );
+    end if;
+
+    raise_application_error(p_error_code, l_msg);
+  end raise_error;
+
+end uc_ai_error;
+/

--- a/src/packages/uc_ai_error.pkb
+++ b/src/packages/uc_ai_error.pkb
@@ -98,7 +98,7 @@ create or replace package body uc_ai_error as
   begin
     return json_object_t.parse(p_response);
   exception
-    when others then
+    when others then -- @dblinter ignore(g-5040): error is handled in raise_error
       l_status_code := apex_web_service.g_status_code;
       l_preview := substr(p_response, 1, 500);
 

--- a/src/packages/uc_ai_error.pks
+++ b/src/packages/uc_ai_error.pks
@@ -151,5 +151,23 @@ as
   , p_log        in boolean  default true
   );
 
+  /**
+   * Parse a provider HTTP response as JSON, raising a descriptive error on failure.
+   *
+   * Replaces scattered begin/exception blocks across providers.
+   * On failure, the raised error includes the provider name,
+   * the HTTP status code, and a truncated preview of the response body.
+   *
+   * @param p_response   Raw HTTP response body (may be HTML, empty, etc.)
+   * @param p_provider   Provider name for the error message (e.g. 'Ollama', 'OCI')
+   * @param p_scope      Logger scope
+   * @return Parsed JSON object
+   */
+  function parse_json_response(
+    p_response in clob
+  , p_provider in varchar2
+  , p_scope    in varchar2
+  ) return json_object_t;
+
 end uc_ai_error;
 /

--- a/src/packages/uc_ai_error.pks
+++ b/src/packages/uc_ai_error.pks
@@ -1,0 +1,155 @@
+create or replace package uc_ai_error 
+  authid definer
+as
+
+  -- @dblinter ignore(g-9108)
+
+  /**
+  * UC AI - Centralized Error Handling
+  * Defines error codes, message templates, and a raise_error procedure
+  * that logs and raises with descriptive messages in one call.
+  *
+  * Each error code has a default message template. Placeholders use
+  * apex_string.format syntax: %0, %1, %2, ... %9
+  *
+  * Example:
+  *   uc_ai_error.raise_error(
+  *     p_error_code => uc_ai_error.c_err_unknown_provider
+  *   , p0           => 'my_provider'
+  *   );
+  *   -- raises: ORA-20306: Unknown AI provider: my_provider
+  *
+  * Override the default message when needed:
+  *   uc_ai_error.raise_error(
+  *     p_error_code => uc_ai_error.c_err_provider_response
+  *   , p_message    => 'Response is not valid JSON'
+  *   , p_extra      => l_resp
+  *   );
+  *
+  * Licensed under the GNU Lesser General Public License v3.0
+  * Copyright (c) 2025-present United Codes
+  * https://www.united-codes.com
+  */
+
+  -- =============================================
+  -- Error code constants
+  -- Range -20301 to -20309: Core / provider errors
+  -- Range -20400 to -20409: Agent errors
+  -- Range -20450 to -20459: Workflow errors
+  -- Range -20500 to -20509: Validation errors
+  -- =============================================
+
+  -- Core / Provider errors (preserving existing codes from uc_ai.pks)
+  c_err_max_calls_exceeded     constant number := -20301;
+  c_err_provider_response      constant number := -20302;
+  c_err_unhandled_format       constant number := -20303;
+  c_err_format_processing      constant number := -20304;
+  c_err_model_not_found        constant number := -20305;
+  c_err_unknown_provider       constant number := -20306;
+  c_err_structured_unsupported constant number := -20307;
+  c_err_reasoning_budget       constant number := -20308;
+
+  -- Agent errors
+  c_err_unknown_agent_type     constant number := -20400;
+  c_err_unknown_workflow_type  constant number := -20401;
+  c_err_agent_retrieval        constant number := -20402;
+  c_err_speaker_not_found      constant number := -20403;
+  c_err_unknown_conv_mode      constant number := -20404;
+
+  -- Workflow errors
+  c_err_missing_output_key     constant number := -20450;
+  c_err_condition_eval         constant number := -20451;
+  c_err_input_mapping_eval     constant number := -20452;
+  c_err_final_message_eval     constant number := -20453;
+  c_err_apex_session           constant number := -20454;
+
+  -- Validation errors
+  c_err_not_found              constant number := -20500;
+  c_err_invalid_status         constant number := -20501;
+  c_err_missing_config         constant number := -20502;
+  c_err_invalid_config         constant number := -20503;
+  c_err_has_references         constant number := -20505;
+  c_err_missing_placeholder    constant number := -20506;
+  c_err_unsupported_content    constant number := -20508;
+
+  -- =============================================
+  -- Default message templates (apex_string.format syntax)
+  -- These are used automatically by raise_error when p_message is null.
+  -- They are public so callers can reference them for documentation.
+  -- =============================================
+
+  -- Core / Provider messages
+  c_msg_max_calls_exceeded     constant varchar2(200 char) := 'Maximum tool calls exceeded (limit: %0)';
+  c_msg_provider_response      constant varchar2(200 char) := 'Error response from provider %0: %1';
+  c_msg_unhandled_format       constant varchar2(200 char) := 'Unsupported %0: %1';
+  c_msg_format_processing      constant varchar2(200 char) := 'Error processing format: %0';
+  c_msg_model_not_found        constant varchar2(200 char) := 'Model not found: %0';
+  c_msg_unknown_provider       constant varchar2(200 char) := 'Unknown AI provider: %0';
+  c_msg_structured_unsupported constant varchar2(200 char) := 'Provider %0 does not support structured output';
+  c_msg_reasoning_budget       constant varchar2(200 char) := 'Reasoning budget tokens (%0) exceed max tokens (%1). Set a higher value.';
+
+  -- Agent messages
+  c_msg_unknown_agent_type     constant varchar2(200 char) := 'Unknown agent type: %0';
+  c_msg_unknown_workflow_type  constant varchar2(200 char) := 'Unknown workflow type: %0';
+  c_msg_agent_retrieval        constant varchar2(200 char) := 'Error retrieving agent: %0';
+  c_msg_speaker_not_found      constant varchar2(200 char) := 'Next speaker "%0" not found among participants';
+  c_msg_unknown_conv_mode      constant varchar2(200 char) := 'Unknown conversation mode: %0';
+
+  -- Workflow messages
+  c_msg_missing_output_key     constant varchar2(200 char) := 'Step definition missing output_key';
+  c_msg_condition_eval         constant varchar2(200 char) := 'Error evaluating condition: %0 - %1';
+  c_msg_input_mapping_eval     constant varchar2(200 char) := 'Error evaluating input mapping key %0: %1';
+  c_msg_final_message_eval     constant varchar2(200 char) := 'Error evaluating final_message: %0 - %1';
+  c_msg_apex_session           constant varchar2(500 char) := 'Cannot create APEX session. Schema needs an APEX Workspace with at least one application.';
+
+  -- Validation messages
+  c_msg_not_found              constant varchar2(200 char) := '%0 not found: %1';
+  c_msg_invalid_status         constant varchar2(200 char) := 'Invalid status value: %0. Allowed: %1';
+  c_msg_missing_config         constant varchar2(200 char) := '%0 requires %1';
+  c_msg_invalid_config         constant varchar2(200 char) := 'Invalid %0: %1';
+  c_msg_has_references         constant varchar2(200 char) := 'Cannot delete "%0": referenced by %1 record(s)';
+  c_msg_missing_placeholder    constant varchar2(200 char) := 'Missing parameter for placeholder: %0';
+  c_msg_unsupported_content    constant varchar2(200 char) := 'Unsupported content type: %0';
+
+  /**
+   * Log an error and raise raise_application_error in one call.
+   *
+   * The default message template for each error code is used automatically.
+   * Pass p_message only to override the default.
+   *
+   * @param p_error_code  One of the c_err_* constants
+   * @param p_scope       Logger scope (e.g., 'uc_ai_agents_api.create_agent')
+   * @param p0            Substitution value for %0
+   * @param p1            Substitution value for %1
+   * @param p2            Substitution value for %2
+   * @param p3            Substitution value for %3
+   * @param p4            Substitution value for %4
+   * @param p5            Substitution value for %5
+   * @param p6            Substitution value for %6
+   * @param p7            Substitution value for %7
+   * @param p8            Substitution value for %8
+   * @param p9            Substitution value for %9
+   * @param p_message     Override message template. If null, the default for p_error_code is used.
+   * @param p_extra       Extra detail passed to uc_ai_logger.log_error (e.g., full JSON response or backtrace)
+   * @param p_log         Whether to log before raising (default true). Set to false when re-raising in an exception handler where logging already happened.
+   */
+  procedure raise_error(
+    p_error_code in number
+  , p_scope      in varchar2 default null
+  , p0           in varchar2 default null
+  , p1           in varchar2 default null
+  , p2           in varchar2 default null
+  , p3           in varchar2 default null
+  , p4           in varchar2 default null
+  , p5           in varchar2 default null
+  , p6           in varchar2 default null
+  , p7           in varchar2 default null
+  , p8           in varchar2 default null
+  , p9           in varchar2 default null
+  , p_message    in varchar2 default null
+  , p_extra      in clob     default null
+  , p_log        in boolean  default true
+  );
+
+end uc_ai_error;
+/

--- a/src/packages/uc_ai_google.pkb
+++ b/src/packages/uc_ai_google.pkb
@@ -301,9 +301,12 @@ create or replace package body uc_ai_google as
     l_web_credential varchar2(255 char);
   begin
     if g_tool_calls >= p_max_tool_calls then
-      uc_ai_logger.log_warn('Max calls reached', l_scope, 'Max calls: ' || g_tool_calls);
       pio_result.put('finish_reason', 'max_tool_calls_exceeded');
-      raise uc_ai.e_max_calls_exceeded;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_max_calls_exceeded
+      , p_scope      => l_scope
+      , p0           => to_char(p_max_tool_calls)
+      );
     end if;
 
     l_input_obj := p_input_obj;
@@ -343,9 +346,13 @@ create or replace package body uc_ai_google as
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-      uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'google'
+      , p1           => l_temp_obj.get_string('message')
+      , p_extra      => l_temp_obj.to_clob
+      );
     end if;
 
     -- Extract and accumulate usage information in global counters
@@ -525,8 +532,11 @@ create or replace package body uc_ai_google as
   
     else
       -- No candidates returned
-      uc_ai_logger.log_error('No candidates in response', l_scope);
-      pio_result.put('finish_reason', 'error');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p_message    => 'No candidates in Google API response'
+      );
     end if;
 
     uc_ai_logger.log('End internal_generate_text - final messages count: ' || pio_messages.get_size, l_scope);
@@ -784,15 +794,23 @@ create or replace package body uc_ai_google as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Response is not JSON, probable error', l_scope, l_resp);
-        raise uc_ai.e_error_response;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p_message    => 'Response is not valid JSON'
+        , p_extra      => l_resp
+        );
     end;
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-      uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'google'
+      , p1           => l_temp_obj.get_string('message')
+      , p_extra      => l_temp_obj.to_clob
+      );
     end if;
 
     -- Google returns embeddings in "embeddings" array, each item has "values" array

--- a/src/packages/uc_ai_google.pkb
+++ b/src/packages/uc_ai_google.pkb
@@ -342,7 +342,7 @@ create or replace package body uc_ai_google as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    l_resp_json := json_object_t.parse(l_resp);
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Google', l_scope);
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
@@ -790,17 +790,7 @@ create or replace package body uc_ai_google as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_provider_response
-        , p_scope      => l_scope
-        , p_message    => 'Response is not valid JSON'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Google', l_scope);
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');

--- a/src/packages/uc_ai_google.pks
+++ b/src/packages/uc_ai_google.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_google as
+create or replace package uc_ai_google 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_logger.pks
+++ b/src/packages/uc_ai_logger.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_logger authid definer as
+create or replace package uc_ai_logger 
+  authid definer 
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_message_api.pks
+++ b/src/packages/uc_ai_message_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_message_api as
+create or replace package uc_ai_message_api 
+  authid definer
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_oci.pkb
+++ b/src/packages/uc_ai_oci.pkb
@@ -516,7 +516,7 @@ create or replace package body uc_ai_oci as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    l_resp_json := json_object_t.parse(l_resp);
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'OCI', l_scope);
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
@@ -1086,18 +1086,7 @@ create or replace package body uc_ai_oci as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_provider_response
-        , p_scope      => l_scope
-        , p0           => 'oci'
-        , p1           => 'Response is not JSON, probable error'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'OCI', l_scope);
 
     -- Check for error in response
     if l_resp_json.has('code') and l_resp_json.has('message') then

--- a/src/packages/uc_ai_oci.pkb
+++ b/src/packages/uc_ai_oci.pkb
@@ -17,6 +17,9 @@ create or replace package body uc_ai_oci as
   g_cohere_system_prompt clob;
   g_cohere_user_message clob;
 
+  g_input_tokens number := 0;
+  g_output_tokens number := 0;
+
   -- OCI Generative AI reference: https://docs.oracle.com/en-us/iaas/api/#/en/generative-ai-inference/20231130/
   function get_text_content_generic (
     p_message in json_object_t
@@ -565,6 +568,12 @@ create or replace package body uc_ai_oci as
     if l_resp_json.has('chatResponse') then
       l_chat_response := l_resp_json.get_object('chatResponse');
 
+      -- Extract and accumulate usage information
+      if l_chat_response.has('usage') then
+        l_temp_obj := l_chat_response.get_object('usage');
+        g_input_tokens := g_input_tokens + nvl(l_temp_obj.get_number('promptTokens'), 0);
+        g_output_tokens := g_output_tokens + nvl(l_temp_obj.get_number('completionTokens'), 0);
+      end if;
 
       if g_mode = gc_mode_generic then
         -- OCI response structure is different from OpenAI/Google
@@ -856,6 +865,7 @@ create or replace package body uc_ai_oci as
   ) return json_object_t
   as
     l_scope uc_ai_logger.scope := c_scope_prefix || 'generate_text_with_messages';
+    l_region varchar2(64 char) := coalesce(g_region, 'us-ashburn-1');
     l_input_obj          json_object_t := json_object_t();
     l_oci_messages       json_array_t;
     l_result             json_object_t;
@@ -864,8 +874,23 @@ create or replace package body uc_ai_oci as
     l_chat_request       json_object_t;
     l_tools              json_array_t;
   begin
-    l_result := json_object_t();
     uc_ai_logger.log('Starting generate_text with ' || p_messages.get_size || ' input messages', l_scope);
+
+    if g_use_responses_api then
+      uc_ai_responses_api.g_base_url := c_api_url_base || l_region || '.oci.oraclecloud.com/openai/v1';
+      uc_ai_responses_api.g_apex_web_credential := coalesce(uc_ai.g_apex_web_credential, g_apex_web_credential);
+      uc_ai_responses_api.g_extra_header_name := 'opc-compartment-id';
+      uc_ai_responses_api.g_extra_header_value := g_compartment_id;
+      uc_ai.g_provider_override := uc_ai.c_provider_oci;
+
+      return uc_ai_responses_api.generate_text(
+        p_messages       => p_messages
+      , p_model          => p_model
+      , p_max_tool_calls => p_max_tool_calls
+      );
+    end if;
+
+    l_result := json_object_t();
 
     if p_model like 'cohere.%' then
       g_mode := gc_mode_cohere;
@@ -877,6 +902,8 @@ create or replace package body uc_ai_oci as
     g_tool_calls := 0;
     g_final_message := null;
     g_normalized_messages := json_array_t();
+    g_input_tokens := 0;
+    g_output_tokens := 0;
     
     -- Copy input messages to global normalized messages array
     <<copy_messages_loop>>
@@ -980,9 +1007,20 @@ create or replace package body uc_ai_oci as
  
     -- Add provider info to the result
     l_result.put('provider', uc_ai.c_provider_oci);
-    
+
+    -- Add usage information
+    declare
+      l_usage_obj json_object_t := json_object_t();
+    begin
+      l_usage_obj.put('prompt_tokens', g_input_tokens);
+      l_usage_obj.put('completion_tokens', g_output_tokens);
+      l_usage_obj.put('reasoning_tokens', cast(null as number));
+      l_usage_obj.put('total_tokens', g_input_tokens + g_output_tokens);
+      l_result.put('usage', l_usage_obj);
+    end;
+
     uc_ai_logger.log('Completed generate_text with final message count: ' || g_normalized_messages.get_size, l_scope);
-    
+
     return l_result;
   end generate_text;
 

--- a/src/packages/uc_ai_oci.pkb
+++ b/src/packages/uc_ai_oci.pkb
@@ -30,8 +30,12 @@ create or replace package body uc_ai_oci as
     l_message := p_message.clone();
 
     if l_message.get_string('type') != 'TEXT' then
-      uc_ai_logger.log_error('Message type is not TEXT.', c_scope_prefix || 'get_text_content_generic', l_message.to_clob);
-      raise uc_ai.e_unhandled_format;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_unsupported_content
+      , p_scope      => c_scope_prefix || 'get_text_content_generic'
+      , p0           => l_message.get_string('type')
+      , p_extra      => l_message.to_clob
+      );
     end if;
 
     l_content := l_message.get_clob('text');
@@ -58,8 +62,12 @@ create or replace package body uc_ai_oci as
     l_lm_text_content  json_object_t;
   begin
     if not p_chat_response.has('text') then
-      uc_ai_logger.log_error('Cohere response does not contain text field', c_scope_prefix || 'get_text_content_cohere');
-      raise uc_ai.e_unhandled_format;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_unhandled_format
+      , p_scope      => c_scope_prefix || 'get_text_content_cohere'
+      , p0           => 'response format'
+      , p1           => 'Cohere response does not contain text field'
+      );
     end if;
 
     l_text := p_chat_response.get_clob('text');
@@ -282,11 +290,17 @@ create or replace package body uc_ai_oci as
                 uc_ai_logger.log('Append user message', l_scope, l_oci_message.to_clob);
                 po_oci_messages.append(l_oci_message);
               when 'file' then
-                uc_ai_logger.log_error('Cohere cannot handle files', l_scope);
-                raise uc_ai.e_unhandled_format;
+                uc_ai_error.raise_error(
+                  p_error_code => uc_ai_error.c_err_unsupported_content
+                , p_scope      => l_scope
+                , p0           => 'file (Cohere cannot handle files)'
+                );
               else
-                uc_ai_logger.log_error('Unknown content type in user message: ' || l_content_type, l_scope);
-                raise uc_ai.e_unhandled_format;
+                uc_ai_error.raise_error(
+                  p_error_code => uc_ai_error.c_err_unsupported_content
+                , p_scope      => l_scope
+                , p0           => l_content_type
+                );
             end case;
           end loop user_content_loop;
           
@@ -332,8 +346,11 @@ create or replace package body uc_ai_oci as
 
                   l_tool_calls.append(l_tool_call);
                 else
-                  uc_ai_logger.log_error('Unknown content type in assistant message: ' || l_content_type, l_scope);
-                  raise uc_ai.e_unhandled_format;
+                  uc_ai_error.raise_error(
+                    p_error_code => uc_ai_error.c_err_unsupported_content
+                  , p_scope      => l_scope
+                  , p0           => l_content_type
+                  );
               end case;
                 l_oci_message := json_object_t();
                 l_oci_message.put('role', 'CHATBOT');
@@ -456,9 +473,12 @@ create or replace package body uc_ai_oci as
     l_code varchar2(255 char);
   begin
     if g_tool_calls >= p_max_tool_calls then
-      uc_ai_logger.log_warn('Max calls reached', l_scope, 'Max calls: ' || g_tool_calls);
       pio_result.put('finish_reason', 'max_tool_calls_exceeded');
-      raise uc_ai.e_max_calls_exceeded;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_max_calls_exceeded
+      , p_scope      => l_scope
+      , p0           => to_char(p_max_tool_calls)
+      );
     end if;
     l_input_obj := p_input_obj;
     l_chat_request := l_input_obj.get_object('chatRequest');
@@ -497,21 +517,40 @@ create or replace package body uc_ai_oci as
 
     if l_resp_json.has('error') then
       l_temp_obj := l_resp_json.get_object('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'oci'
+      , p1           => 'Error in response'
+      , p_extra      => l_temp_obj.to_clob
+      );
     elsif l_resp_json.has('code') then
       l_code := l_resp_json.get_string('code');
       uc_ai_logger.log('API returned code: ' || l_code, l_scope);
-      case l_code 
+      case l_code
         when '400' then
-          uc_ai_logger.log_error('Bad request', l_scope);
-          raise uc_ai.e_error_response;
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_provider_response
+          , p_scope      => l_scope
+          , p0           => 'oci'
+          , p1           => 'Bad request (400)'
+          , p_extra      => l_resp
+          );
         when '401' then
-          uc_ai_logger.log_error('Authentication error', l_scope);
-          raise uc_ai.e_error_response;
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_provider_response
+          , p_scope      => l_scope
+          , p0           => 'oci'
+          , p1           => 'Authentication error (401)'
+          , p_extra      => l_resp
+          );
         when '404' then
-          uc_ai_logger.log_error('Model not found', l_scope);
-          raise uc_ai.e_model_not_found_error;
+          uc_ai_error.raise_error(
+            p_error_code => uc_ai_error.c_err_model_not_found
+          , p_scope      => l_scope
+          , p0           => l_resp_json.get_string('message')
+          , p_extra      => l_resp
+          );
         else
           null;
       end case;
@@ -855,8 +894,12 @@ create or replace package body uc_ai_oci as
     -- Build OCI request structure
     -- Set compartment ID (must be configured)
     if g_compartment_id is null then
-      uc_ai_logger.log_error('OCI compartment ID not configured', l_scope);
-      raise_application_error(-20001, 'OCI compartment ID (g_compartment_id) must be configured');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_missing_config
+      , p_scope      => l_scope
+      , p0           => 'OCI provider'
+      , p1           => 'g_compartment_id to be configured'
+      );
     end if;
     
     l_input_obj.put('compartmentId', g_compartment_id);
@@ -1009,15 +1052,24 @@ create or replace package body uc_ai_oci as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Response is not JSON, probable error', l_scope, l_resp);
-        raise uc_ai.e_error_response;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'oci'
+        , p1           => 'Response is not JSON, probable error'
+        , p_extra      => l_resp
+        );
     end;
 
     -- Check for error in response
     if l_resp_json.has('code') and l_resp_json.has('message') then
-      uc_ai_logger.log_error('Error in response', l_scope, l_resp_json.to_clob);
-      uc_ai_logger.log_error('Error message: ', l_scope, l_resp_json.get_string('message'));
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'oci'
+      , p1           => l_resp_json.get_string('message')
+      , p_extra      => l_resp_json.to_clob
+      );
     end if;
 
     -- OCI returns embeddings directly as an array of arrays

--- a/src/packages/uc_ai_oci.pks
+++ b/src/packages/uc_ai_oci.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_oci as
+create or replace package uc_ai_oci 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_oci.pks
+++ b/src/packages/uc_ai_oci.pks
@@ -62,6 +62,7 @@ as
   g_serving_type varchar2(64 char) := 'ON_DEMAND'; -- ON_DEMAND or DEDICATED
   g_region varchar2(64 char) := 'us-ashburn-1'; -- OCI region for API endpoint
   g_apex_web_credential varchar2(255 char);
+  g_use_responses_api boolean := false;
 
   /*
    * Oracle Cloud Infrastructure (OCI) Generative AI implementation for text generation 

--- a/src/packages/uc_ai_ollama.pkb
+++ b/src/packages/uc_ai_ollama.pkb
@@ -316,17 +316,7 @@ create or replace package body uc_ai_ollama as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_format_processing
-        , p_scope      => l_scope
-        , p0           => 'Error parsing response JSON'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Ollama', l_scope);
 
     if l_resp_json.has('error') then
       uc_ai_error.raise_error(
@@ -552,9 +542,36 @@ create or replace package body uc_ai_ollama as
     l_message            json_object_t;
     l_format             json_object_t;
   begin
-    l_result := json_object_t();
     uc_ai_logger.log('Starting generate_text with ' || p_messages.get_size || ' input messages', l_scope);
-    
+
+    if g_use_responses_api then
+      declare
+        l_base varchar2(500 char) := coalesce(uc_ai.g_base_url, c_api_url);
+      begin
+        -- Replace /api suffix with /v1 for OpenAI-compatible endpoint
+        if l_base like '%/api' then
+          l_base := substr(l_base, 1, length(l_base) - 4) || '/v1';
+        else
+          l_base := rtrim(l_base, '/') || '/v1';
+        end if;
+        uc_ai_responses_api.g_base_url := l_base;
+        uc_ai_responses_api.g_apex_web_credential := coalesce(uc_ai.g_apex_web_credential, g_apex_web_credential);
+        uc_ai_responses_api.g_skip_auth := uc_ai_responses_api.g_apex_web_credential is null;
+        uc_ai.g_provider_override := uc_ai.c_provider_ollama;
+        -- Clear g_base_url so responses API uses its own g_base_url
+        uc_ai.g_base_url := null;
+
+        return uc_ai_responses_api.generate_text(
+          p_messages       => p_messages
+        , p_model          => p_model
+        , p_max_tool_calls => p_max_tool_calls
+        , p_schema         => p_schema
+        );
+      end;
+    end if;
+
+    l_result := json_object_t();
+
     -- Reset global variables
     g_tool_calls := 0;
     g_final_message := null;
@@ -655,13 +672,13 @@ create or replace package body uc_ai_ollama as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    l_resp_json := json_object_t.parse(l_resp);
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Ollama', l_scope);
 
     if l_resp_json.has('error') then
       uc_ai_error.raise_error(
         p_error_code => uc_ai_error.c_err_provider_response
       , p_scope      => l_scope
-      , p0           => 'ollama'
+      , p0           => 'Ollama'
       , p1           => l_resp_json.get_clob('error')
       , p_extra      => l_resp
       );

--- a/src/packages/uc_ai_ollama.pkb
+++ b/src/packages/uc_ai_ollama.pkb
@@ -97,12 +97,12 @@ create or replace package body uc_ai_ollama as
     l_lm_reasoning_content := get_reasoning_content(p_message);
 
     if l_lm_reasoning_content is null and l_lm_text_content is null then
-      uc_ai_logger.log_error(
-        'No content to process response',
-        c_scope_prefix || 'process_llm_response',
-        p_message.to_clob
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_format_processing
+      , p_scope      => c_scope_prefix || 'process_llm_response'
+      , p0           => 'No content to process response'
+      , p_extra      => p_message.to_clob
       );
-      raise uc_ai.e_format_processing_error;
     end if;
 
     l_arr := json_array_t();
@@ -287,9 +287,12 @@ create or replace package body uc_ai_ollama as
     l_has_tool_calls boolean := false;
   begin
     if g_tool_calls >= p_max_tool_calls then
-      uc_ai_logger.log_warn('Max calls reached', l_scope, 'Max calls: ' || g_tool_calls);
       pio_result.put('finish_reason', 'max_tool_calls_exceeded');
-      raise uc_ai.e_max_calls_exceeded;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_max_calls_exceeded
+      , p_scope      => l_scope
+      , p0           => to_char(p_max_tool_calls)
+      );
     end if;
 
     l_input_obj := p_input_obj;
@@ -317,14 +320,22 @@ create or replace package body uc_ai_ollama as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Error parsing response JSON', l_scope, l_resp);
-        raise uc_ai.e_format_processing_error;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_format_processing
+        , p_scope      => l_scope
+        , p0           => 'Error parsing response JSON'
+        , p_extra      => l_resp
+        );
     end;
 
     if l_resp_json.has('error') then
-      l_resp := l_resp_json.get_clob('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_resp);
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'ollama'
+      , p1           => l_resp_json.get_clob('error')
+      , p_extra      => l_resp
+      );
     end if;
 
     -- Extract and store usage information (if available in Ollama response)
@@ -647,9 +658,13 @@ create or replace package body uc_ai_ollama as
     l_resp_json := json_object_t.parse(l_resp);
 
     if l_resp_json.has('error') then
-      l_resp := l_resp_json.get_clob('error');
-      uc_ai_logger.log_error('Error in response', l_scope, l_resp);
-      raise uc_ai.e_error_response;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_provider_response
+      , p_scope      => l_scope
+      , p0           => 'ollama'
+      , p1           => l_resp_json.get_clob('error')
+      , p_extra      => l_resp
+      );
     end if;
 
     l_embeddings := l_resp_json.get_array('embeddings');

--- a/src/packages/uc_ai_ollama.pks
+++ b/src/packages/uc_ai_ollama.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_ollama as
+create or replace package uc_ai_ollama 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_ollama.pks
+++ b/src/packages/uc_ai_ollama.pks
@@ -15,6 +15,7 @@ as
   -- See https://ollama.com/library for available models
 
   g_apex_web_credential varchar2(255 char);
+  g_use_responses_api boolean := false;
 
   /*
    * Ollama implementation for text generation

--- a/src/packages/uc_ai_openai.pkb
+++ b/src/packages/uc_ai_openai.pkb
@@ -340,17 +340,7 @@ create or replace package body uc_ai_openai as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_provider_response
-        , p_scope      => l_scope
-        , p_message    => 'Response is not valid JSON'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'OpenAI', l_scope);
 
     if l_resp_json.has('error') then
       if l_resp_json.get('error').is_object then
@@ -772,17 +762,7 @@ create or replace package body uc_ai_openai as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_provider_response
-        , p_scope      => l_scope
-        , p_message    => 'Response is not valid JSON'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'OpenAI', l_scope);
 
     if l_resp_json.has('error') then
       if l_resp_json.get('error').is_object then

--- a/src/packages/uc_ai_openai.pkb
+++ b/src/packages/uc_ai_openai.pkb
@@ -160,15 +160,24 @@ create or replace package body uc_ai_openai as
                     l_image_url.put('url', 'data:' || l_mime_type || ';base64,' || l_data);
                     l_new_content_item.put('image_url', l_image_url);
                   else
-                    uc_ai_logger.log_error('Unsupported file type: ' || l_mime_type, l_scope, l_content_item.stringify);
-                    raise uc_ai.e_unhandled_format;
+                    uc_ai_error.raise_error(
+                      p_error_code => uc_ai_error.c_err_unhandled_format
+                    , p_scope      => l_scope
+                    , p0           => 'file type'
+                    , p1           => l_mime_type
+                    , p_extra      => l_content_item.stringify
+                    );
                   end if;
 
                   l_new_content.append(l_new_content_item);
                 end;
               else
-                uc_ai_logger.log_error('Unknown content type in user message: ' || l_content_type, l_scope, l_content_item.stringify);
-                raise uc_ai.e_unhandled_format;
+                uc_ai_error.raise_error(
+                  p_error_code => uc_ai_error.c_err_unsupported_content
+                , p_scope      => l_scope
+                , p0           => l_content_type
+                , p_extra      => l_content_item.stringify
+                );
             end case;
           end loop user_content_loop;
           
@@ -288,9 +297,12 @@ create or replace package body uc_ai_openai as
     l_web_credential varchar2(255 char);
   begin
     if g_tool_calls >= p_max_tool_calls then
-      uc_ai_logger.log_warn('Max calls reached', l_scope, 'Max calls: ' || g_tool_calls);
       pio_result.put('finish_reason', 'max_tool_calls_exceeded');
-      raise uc_ai.e_max_calls_exceeded;
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_max_calls_exceeded
+      , p_scope      => l_scope
+      , p0           => to_char(p_max_tool_calls)
+      );
     end if;
 
     l_input_obj := p_input_obj.clone();
@@ -332,19 +344,32 @@ create or replace package body uc_ai_openai as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Response is not JSON, probable error', l_scope, l_resp);
-        raise uc_ai.e_error_response;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p_message    => 'Response is not valid JSON'
+        , p_extra      => l_resp
+        );
     end;
 
     if l_resp_json.has('error') then
       if l_resp_json.get('error').is_object then
         l_temp_obj := l_resp_json.get_object('error');
-        uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-        uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'openai'
+        , p1           => l_temp_obj.get_string('message')
+        , p_extra      => l_temp_obj.to_clob
+        );
       else
-        uc_ai_logger.log_error('Error in response', l_scope, l_resp_json.get_string('error'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'openai'
+        , p1           => l_resp_json.get_string('error')
+        );
       end if;
-      raise uc_ai.e_error_response;
     end if;
 
     -- Extract and accumulate usage information in global counters
@@ -751,19 +776,32 @@ create or replace package body uc_ai_openai as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Response is not JSON, probable error', l_scope, l_resp);
-        raise uc_ai.e_error_response;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p_message    => 'Response is not valid JSON'
+        , p_extra      => l_resp
+        );
     end;
 
     if l_resp_json.has('error') then
       if l_resp_json.get('error').is_object then
         l_temp_obj := l_resp_json.get_object('error');
-        uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-        uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'openai'
+        , p1           => l_temp_obj.get_string('message')
+        , p_extra      => l_temp_obj.to_clob
+        );
       else
-        uc_ai_logger.log_error('Error in response', l_scope, l_resp_json.get_string('error'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'openai'
+        , p1           => l_resp_json.get_string('error')
+        );
       end if;
-      raise uc_ai.e_error_response;
     end if;
 
     -- OpenAI returns embeddings in "data" array, each item has "embedding" array

--- a/src/packages/uc_ai_openai.pks
+++ b/src/packages/uc_ai_openai.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_openai as
+create or replace package uc_ai_openai
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_openrouter.pks
+++ b/src/packages/uc_ai_openrouter.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_openrouter as
+create or replace package uc_ai_openrouter 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_prompt_profiles_api.pkb
+++ b/src/packages/uc_ai_prompt_profiles_api.pkb
@@ -89,8 +89,12 @@ create or replace package body uc_ai_prompt_profiles_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'ID ' || p_id
+      );
     end if;
   exception
     when others then
@@ -131,8 +135,12 @@ create or replace package body uc_ai_prompt_profiles_api as
       and version = p_version;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with code: ' || p_code || ', version: ' || p_version);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'code ' || p_code || ', version ' || p_version
+      );
     end if;
   exception
     when others then
@@ -155,8 +163,12 @@ create or replace package body uc_ai_prompt_profiles_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'ID ' || p_id
+      );
     end if;
   exception
     when others then
@@ -181,8 +193,12 @@ create or replace package body uc_ai_prompt_profiles_api as
       and version = p_version;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with code: ' || p_code || ', version: ' || p_version);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'code ' || p_code || ', version ' || p_version
+      );
     end if;
   exception
     when others then
@@ -204,8 +220,12 @@ create or replace package body uc_ai_prompt_profiles_api as
 
     -- Validate status value
     if p_status not in ('draft', 'active', 'archived') then
-      uc_ai_logger.log_error('Invalid status value: ' || p_status, l_scope);
-      raise_application_error(-20002, 'Invalid status. Must be: draft, active, or archived');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_invalid_status
+      , p_scope      => l_scope
+      , p0           => p_status
+      , p1           => 'draft, active, archived'
+      );
     end if;
 
     update uc_ai_prompt_profiles
@@ -213,8 +233,12 @@ create or replace package body uc_ai_prompt_profiles_api as
     where id = p_id;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'ID ' || p_id
+      );
     end if;
   exception
     when others then
@@ -237,8 +261,12 @@ create or replace package body uc_ai_prompt_profiles_api as
 
     -- Validate status value
     if p_status not in (c_status_draft, c_status_active, c_status_archived) then
-      uc_ai_logger.log_error('Invalid status value: ' || p_status, l_scope);
-      raise_application_error(-20002, 'Invalid status. Must be: draft, active, or archived');
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_invalid_status
+      , p_scope      => l_scope
+      , p0           => p_status
+      , p1           => 'draft, active, archived'
+      );
     end if;
 
     update uc_ai_prompt_profiles
@@ -247,8 +275,12 @@ create or replace package body uc_ai_prompt_profiles_api as
       and version = p_version;
 
     if sql%rowcount = 0 then
-      uc_ai_logger.log_error('Prompt profile not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with code: ' || p_code || ', version: ' || p_version);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'code ' || p_code || ', version ' || p_version
+      );
     end if;
   exception
     when others then
@@ -281,8 +313,12 @@ create or replace package body uc_ai_prompt_profiles_api as
         and version = p_source_version;
     exception
       when no_data_found then
-        uc_ai_logger.log_error('Source profile not found with code: ' || p_code || ', version: ' || p_source_version, l_scope);
-        raise_application_error(-20001, 'Source profile not found with code: ' || p_code || ', version: ' || p_source_version);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Source profile'
+        , p1           => 'code ' || p_code || ', version ' || p_source_version
+        );
     end;
 
     -- Determine new version number
@@ -350,8 +386,12 @@ create or replace package body uc_ai_prompt_profiles_api as
     return l_profile;
   exception
     when no_data_found then
-      uc_ai_logger.log_error('Prompt profile not found with ID: ' || p_id, l_scope);
-      raise_application_error(-20001, 'Prompt profile not found with ID: ' || p_id);
+      uc_ai_error.raise_error(
+        p_error_code => uc_ai_error.c_err_not_found
+      , p_scope      => l_scope
+      , p0           => 'Prompt profile'
+      , p1           => 'ID ' || p_id
+      );
     when others then
       uc_ai_logger.log_error('Error getting prompt profile', l_scope);
       raise;
@@ -391,11 +431,19 @@ create or replace package body uc_ai_prompt_profiles_api as
   exception
     when no_data_found then
       if p_version is null then
-        uc_ai_logger.log_error('No active prompt profile found with code: ' || p_code, l_scope);
-        raise_application_error(-20001, 'No active prompt profile found with code: ' || p_code);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Active prompt profile'
+        , p1           => 'code ' || p_code
+        );
       else
-        uc_ai_logger.log_error('Prompt profile not found with code: ' || p_code || ', version: ' || p_version, l_scope);
-        raise_application_error(-20001, 'Prompt profile not found with code: ' || p_code || ', version: ' || p_version);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_not_found
+        , p_scope      => l_scope
+        , p0           => 'Prompt profile'
+        , p1           => 'code ' || p_code || ', version ' || p_version
+        );
       end if;
     when others then
       uc_ai_logger.log_error('Error getting prompt profile', l_scope);
@@ -499,8 +547,12 @@ create or replace package body uc_ai_prompt_profiles_api as
       end if;
       
       if not l_found then
-        uc_ai_logger.log_error('Missing parameter for placeholder: ' || l_placeholder, l_scope, p_parameters.to_clob);
-        raise_application_error(-20003, 'Missing parameter for placeholder: ' || l_placeholder);
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_missing_placeholder
+        , p_scope      => l_scope
+        , p0           => l_placeholder
+        , p_extra      => p_parameters.to_clob
+        );
       end if;
       
       -- Move to next placeholder
@@ -562,7 +614,7 @@ create or replace package body uc_ai_prompt_profiles_api as
           end if;
         when 'g_apex_web_credential' then
           if l_value.is_string then
-            uc_ai.g_apex_web_credential := p_config.get_string(l_key);
+            uc_ai.g_apex_web_credential := coalesce(p_config.get_string(l_key), uc_ai.g_apex_web_credential);
           end if;
         when 'g_tool_tags' then
           declare

--- a/src/packages/uc_ai_prompt_profiles_api.pks
+++ b/src/packages/uc_ai_prompt_profiles_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_prompt_profiles_api as
+create or replace package uc_ai_prompt_profiles_api 
+  authid definer
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_responses_api.pkb
+++ b/src/packages/uc_ai_responses_api.pkb
@@ -960,7 +960,7 @@ create or replace package body uc_ai_responses_api as
         l_usage_obj json_object_t := json_object_t();
         l_input_tokens number := nvl(l_api_usage.get_number('input_tokens'), 0);
         l_output_tokens number := nvl(l_api_usage.get_number('output_tokens'), 0);
-        l_reasoning_tokens number := null;
+        l_reasoning_tokens number;
       begin
         if l_api_usage.has('output_tokens_details') and not l_api_usage.get('output_tokens_details').is_null then
           l_reasoning_tokens := l_api_usage.get_object('output_tokens_details').get_number('reasoning_tokens');

--- a/src/packages/uc_ai_responses_api.pkb
+++ b/src/packages/uc_ai_responses_api.pkb
@@ -541,7 +541,7 @@ create or replace package body uc_ai_responses_api as
 
     l_web_credential := coalesce(g_apex_web_credential, uc_ai.g_apex_web_credential);
 
-    if l_web_credential is null then
+    if l_web_credential is null and not g_skip_auth then
       apex_web_service.g_request_headers(2).name := 'Authorization';
       apex_web_service.g_request_headers(2).value := 'Bearer '||uc_ai_get_key(uc_ai.g_provider_override);
     end if;
@@ -563,18 +563,7 @@ create or replace package body uc_ai_responses_api as
 
     uc_ai_logger.log('Response', l_scope, l_resp);
 
-    begin
-      l_resp_json := json_object_t.parse(l_resp);
-    exception
-      when others then
-        uc_ai_error.raise_error(
-          p_error_code => uc_ai_error.c_err_provider_response
-        , p_scope      => l_scope
-        , p0           => 'Responses API'
-        , p1           => 'Response is not JSON'
-        , p_extra      => l_resp
-        );
-    end;
+    l_resp_json := uc_ai_error.parse_json_response(l_resp, 'Responses API', l_scope);
 
     if l_resp_json.has('error') and not l_resp_json.get('error').is_null then
       if l_resp_json.get('error').is_object then

--- a/src/packages/uc_ai_responses_api.pkb
+++ b/src/packages/uc_ai_responses_api.pkb
@@ -546,6 +546,11 @@ create or replace package body uc_ai_responses_api as
       apex_web_service.g_request_headers(2).value := 'Bearer '||uc_ai_get_key(uc_ai.g_provider_override);
     end if;
 
+    if g_extra_header_name is not null then
+      apex_web_service.g_request_headers(apex_web_service.g_request_headers.count + 1).name := g_extra_header_name;
+      apex_web_service.g_request_headers(apex_web_service.g_request_headers.count).value := g_extra_header_value;
+    end if;
+
     l_url := get_generate_text_url;
     uc_ai_logger.log('Calling Responses API at ' || l_url || '. Web Credential: ' || nvl(l_web_credential, 'null'), l_scope);
 
@@ -959,9 +964,24 @@ create or replace package body uc_ai_responses_api as
       l_result.put('finish_reason', 'stop');
     end if;
     
-    -- Add usage information
+    -- Add normalized usage information
     if l_api_response.has('usage') then
-      l_result.put('usage', l_api_response.get_object('usage'));
+      declare
+        l_api_usage json_object_t := l_api_response.get_object('usage');
+        l_usage_obj json_object_t := json_object_t();
+        l_input_tokens number := nvl(l_api_usage.get_number('input_tokens'), 0);
+        l_output_tokens number := nvl(l_api_usage.get_number('output_tokens'), 0);
+        l_reasoning_tokens number := null;
+      begin
+        if l_api_usage.has('output_tokens_details') and not l_api_usage.get('output_tokens_details').is_null then
+          l_reasoning_tokens := l_api_usage.get_object('output_tokens_details').get_number('reasoning_tokens');
+        end if;
+        l_usage_obj.put('prompt_tokens', l_input_tokens);
+        l_usage_obj.put('completion_tokens', l_output_tokens);
+        l_usage_obj.put('reasoning_tokens', l_reasoning_tokens);
+        l_usage_obj.put('total_tokens', nvl(l_api_usage.get_number('total_tokens'), l_input_tokens + l_output_tokens));
+        l_result.put('usage', l_usage_obj);
+      end;
     end if;
     
     -- Add model information
@@ -970,7 +990,7 @@ create or replace package body uc_ai_responses_api as
     end if;
     
     -- Add provider info
-    l_result.put('provider', uc_ai.c_provider_openai);
+    l_result.put('provider', coalesce(uc_ai.g_provider_override, uc_ai.c_provider_openai));
     
     uc_ai_logger.log('Completed generate_text with Responses API', l_scope);
     

--- a/src/packages/uc_ai_responses_api.pkb
+++ b/src/packages/uc_ai_responses_api.pkb
@@ -105,13 +105,20 @@ create or replace package body uc_ai_responses_api as
                     l_resp_content_item.put('filename', l_content_item.get_string('filename'));
                     l_resp_content_item.put('file_data', 'data:application/pdf;base64,' || l_content_item.get_clob('data'));
                   else
-                    uc_ai_logger.log_warn('Unsupported file media type: ' || l_media_type, l_scope);
-                    raise uc_ai.e_unhandled_format;
+                    uc_ai_error.raise_error(
+                      p_error_code => uc_ai_error.c_err_unhandled_format
+                    , p_scope      => l_scope
+                    , p0           => 'file media type'
+                    , p1           => l_media_type
+                    );
                   end if;
 
                 else
-                  uc_ai_logger.log_warn('Unknown user content type: ' || l_content_item.get_string('type'), l_scope);
-                  raise uc_ai.e_unhandled_format;
+                  uc_ai_error.raise_error(
+                    p_error_code => uc_ai_error.c_err_unsupported_content
+                  , p_scope      => l_scope
+                  , p0           => l_content_item.get_string('type')
+                  );
               end case;
 
               l_new_content.append(l_resp_content_item);
@@ -555,19 +562,33 @@ create or replace package body uc_ai_responses_api as
       l_resp_json := json_object_t.parse(l_resp);
     exception
       when others then
-        uc_ai_logger.log_error('Response is not JSON, probable error', l_scope, l_resp);
-        raise uc_ai.e_error_response;
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'Responses API'
+        , p1           => 'Response is not JSON'
+        , p_extra      => l_resp
+        );
     end;
 
     if l_resp_json.has('error') and not l_resp_json.get('error').is_null then
       if l_resp_json.get('error').is_object then
         l_temp_obj := l_resp_json.get_object('error');
-        uc_ai_logger.log_error('Error in response', l_scope, l_temp_obj.to_clob);
-        uc_ai_logger.log_error('Error message: ', l_scope, l_temp_obj.get_string('message'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'Responses API'
+        , p1           => l_temp_obj.get_string('message')
+        , p_extra      => l_temp_obj.to_clob
+        );
       else
-        uc_ai_logger.log_error('Error in response', l_scope, l_resp_json.get_string('error'));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_provider_response
+        , p_scope      => l_scope
+        , p0           => 'Responses API'
+        , p1           => l_resp_json.get_string('error')
+        );
       end if;
-      raise uc_ai.e_error_response;
     end if;
 
     return l_resp_json;

--- a/src/packages/uc_ai_responses_api.pks
+++ b/src/packages/uc_ai_responses_api.pks
@@ -39,6 +39,9 @@ as
   g_extra_header_name  varchar2(255 char);
   g_extra_header_value varchar2(4000 char);
 
+  -- Skip Authorization header (for providers like Ollama that don't require auth)
+  g_skip_auth boolean := false;
+
 
   /*
    * Responses API implementation for text generation

--- a/src/packages/uc_ai_responses_api.pks
+++ b/src/packages/uc_ai_responses_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_responses_api as
+create or replace package uc_ai_responses_api 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/packages/uc_ai_responses_api.pks
+++ b/src/packages/uc_ai_responses_api.pks
@@ -34,6 +34,11 @@ as
   -- type: HTTP-Header, credential-name: Authorization, value: Bearer <token>
   g_apex_web_credential varchar2(255 char);
 
+  -- Extra HTTP headers to send with requests (e.g., opc-compartment-id for OCI)
+  -- Set by provider packages before calling generate_text, cleared after use.
+  g_extra_header_name  varchar2(255 char);
+  g_extra_header_value varchar2(4000 char);
+
 
   /*
    * Responses API implementation for text generation

--- a/src/packages/uc_ai_structured_output.pkb
+++ b/src/packages/uc_ai_structured_output.pkb
@@ -375,8 +375,11 @@ create or replace package body uc_ai_structured_output as
       when uc_ai.c_provider_anthropic then
         l_result := to_anthropic_format(p_schema);
       else
-        uc_ai_logger.log_error('Unsupported provider for structured output: ' || p_provider, l_scope);
-        raise_application_error(-20999, 'Provider ' || p_provider || ' does not support structured output');
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_structured_unsupported
+        , p_scope      => l_scope
+        , p0           => p_provider
+        );
     end case;
     
     return l_result;

--- a/src/packages/uc_ai_structured_output.pks
+++ b/src/packages/uc_ai_structured_output.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_structured_output as
+create or replace package uc_ai_structured_output 
+  authid definer
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_tools_api.pkb
+++ b/src/packages/uc_ai_tools_api.pkb
@@ -977,7 +977,10 @@ create or replace package body uc_ai_tools_api as
   end create_parameters_recursive;
 
   /*
-   * Creates a new tool definition from a JSON schema
+   * Creates or updates a tool definition from a JSON schema
+   * 
+   * If a tool with the same code already exists, it will be updated.
+   * Parameters and tags are replaced (deleted and recreated) on update.
    */
   function create_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,
@@ -994,43 +997,81 @@ create or replace package body uc_ai_tools_api as
     l_scope uc_ai_logger.scope := gc_scope_prefix || 'create_tool_from_schema';
     
     l_tool_id uc_ai_tools.id%type;
+    l_existing_tool_id uc_ai_tools.id%type;
     l_properties json_object_t;
     l_required_arr json_array_t;
     l_required_keys_arr json_key_list := json_key_list();
     l_schema_clob clob;
   begin
-    uc_ai_logger.log('Creating tool from schema', l_scope, 'Tool: ' || p_tool_code);
+    uc_ai_logger.log('Creating/updating tool from schema', l_scope, 'Tool: ' || p_tool_code);
 
     l_schema_clob := case when p_json_schema is not null then p_json_schema.to_clob else null end;
 
-    -- Create the tool record
-    insert into uc_ai_tools (
-      code,
-      description,
-      active,
-      response_schema,
-      version,
-      function_call,
-      authorization_schema,
-      created_by,
-      created_at,
-      updated_by,
-      updated_at
-    ) values (
-      p_tool_code,
-      p_description,
-      p_active,
-      l_schema_clob, -- Store the original schema for reference
-      p_version,
-      p_function_call,
-      p_authorization_schema,
-      p_created_by,
-      systimestamp,
-      p_created_by,
-      systimestamp
-    ) returning id into l_tool_id;
-    
-    uc_ai_logger.log('Created tool with ID: ' || l_tool_id, l_scope);
+    -- Check if tool already exists
+    begin
+      select id
+        into l_existing_tool_id
+        from uc_ai_tools
+       where code = p_tool_code;
+    exception
+      when no_data_found then
+        l_existing_tool_id := null;
+    end;
+
+    if l_existing_tool_id is not null then
+      -- Update existing tool
+      update uc_ai_tools
+         set description          = p_description,
+             active               = p_active,
+             response_schema      = l_schema_clob,
+             version              = p_version,
+             function_call        = p_function_call,
+             authorization_schema = p_authorization_schema,
+             updated_by           = p_created_by,
+             updated_at           = systimestamp
+       where id = l_existing_tool_id;
+      
+      l_tool_id := l_existing_tool_id;
+      
+      uc_ai_logger.log('Updated existing tool with ID: ' || l_tool_id, l_scope);
+      
+      -- Delete existing parameters (cascade will handle nested params)
+      delete from uc_ai_tool_parameters
+       where tool_id = l_tool_id;
+      
+      -- Delete existing tags
+      delete from uc_ai_tool_tags
+       where tool_id = l_tool_id;
+    else
+      -- Create new tool record
+      insert into uc_ai_tools (
+        code,
+        description,
+        active,
+        response_schema,
+        version,
+        function_call,
+        authorization_schema,
+        created_by,
+        created_at,
+        updated_by,
+        updated_at
+      ) values (
+        p_tool_code,
+        p_description,
+        p_active,
+        l_schema_clob, -- Store the original schema for reference
+        p_version,
+        p_function_call,
+        p_authorization_schema,
+        p_created_by,
+        systimestamp,
+        p_created_by,
+        systimestamp
+      ) returning id into l_tool_id;
+      
+      uc_ai_logger.log('Created new tool with ID: ' || l_tool_id, l_scope);
+    end if;
 
     if l_schema_clob is null then
       return l_tool_id;
@@ -1078,7 +1119,7 @@ create or replace package body uc_ai_tools_api as
         );
     end if;
     
-    uc_ai_logger.log('Successfully created tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
+    uc_ai_logger.log('Successfully created/updated tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
     
     return l_tool_id;
     

--- a/src/packages/uc_ai_tools_api.pkb
+++ b/src/packages/uc_ai_tools_api.pkb
@@ -989,7 +989,10 @@ create or replace package body uc_ai_tools_api as
   end create_parameters_recursive;
 
   /*
-   * Creates a new tool definition from a JSON schema
+   * Creates or updates a tool definition from a JSON schema
+   * 
+   * If a tool with the same code already exists, it will be updated.
+   * Parameters and tags are replaced (deleted and recreated) on update.
    */
   function create_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,
@@ -1006,43 +1009,81 @@ create or replace package body uc_ai_tools_api as
     l_scope uc_ai_logger.scope := gc_scope_prefix || 'create_tool_from_schema';
     
     l_tool_id uc_ai_tools.id%type;
+    l_existing_tool_id uc_ai_tools.id%type;
     l_properties json_object_t;
     l_required_arr json_array_t;
     l_required_keys_arr json_key_list := json_key_list();
     l_schema_clob clob;
   begin
-    uc_ai_logger.log('Creating tool from schema', l_scope, 'Tool: ' || p_tool_code);
+    uc_ai_logger.log('Creating/updating tool from schema', l_scope, 'Tool: ' || p_tool_code);
 
     l_schema_clob := case when p_json_schema is not null then p_json_schema.to_clob else null end;
 
-    -- Create the tool record
-    insert into uc_ai_tools (
-      code,
-      description,
-      active,
-      response_schema,
-      version,
-      function_call,
-      authorization_schema,
-      created_by,
-      created_at,
-      updated_by,
-      updated_at
-    ) values (
-      p_tool_code,
-      p_description,
-      p_active,
-      l_schema_clob, -- Store the original schema for reference
-      p_version,
-      p_function_call,
-      p_authorization_schema,
-      p_created_by,
-      systimestamp,
-      p_created_by,
-      systimestamp
-    ) returning id into l_tool_id;
-    
-    uc_ai_logger.log('Created tool with ID: ' || l_tool_id, l_scope);
+    -- Check if tool already exists
+    begin
+      select id
+        into l_existing_tool_id
+        from uc_ai_tools
+       where code = p_tool_code;
+    exception
+      when no_data_found then
+        l_existing_tool_id := null;
+    end;
+
+    if l_existing_tool_id is not null then
+      -- Update existing tool
+      update uc_ai_tools
+         set description          = p_description,
+             active               = p_active,
+             response_schema      = l_schema_clob,
+             version              = p_version,
+             function_call        = p_function_call,
+             authorization_schema = p_authorization_schema,
+             updated_by           = p_created_by,
+             updated_at           = systimestamp
+       where id = l_existing_tool_id;
+      
+      l_tool_id := l_existing_tool_id;
+      
+      uc_ai_logger.log('Updated existing tool with ID: ' || l_tool_id, l_scope);
+      
+      -- Delete existing parameters (cascade will handle nested params)
+      delete from uc_ai_tool_parameters
+       where tool_id = l_tool_id;
+      
+      -- Delete existing tags
+      delete from uc_ai_tool_tags
+       where tool_id = l_tool_id;
+    else
+      -- Create new tool record
+      insert into uc_ai_tools (
+        code,
+        description,
+        active,
+        response_schema,
+        version,
+        function_call,
+        authorization_schema,
+        created_by,
+        created_at,
+        updated_by,
+        updated_at
+      ) values (
+        p_tool_code,
+        p_description,
+        p_active,
+        l_schema_clob, -- Store the original schema for reference
+        p_version,
+        p_function_call,
+        p_authorization_schema,
+        p_created_by,
+        systimestamp,
+        p_created_by,
+        systimestamp
+      ) returning id into l_tool_id;
+      
+      uc_ai_logger.log('Created new tool with ID: ' || l_tool_id, l_scope);
+    end if;
 
     if l_schema_clob is null then
       return l_tool_id;
@@ -1090,7 +1131,7 @@ create or replace package body uc_ai_tools_api as
         );
     end if;
     
-    uc_ai_logger.log('Successfully created tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
+    uc_ai_logger.log('Successfully created/updated tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
     
     return l_tool_id;
     

--- a/src/packages/uc_ai_tools_api.pkb
+++ b/src/packages/uc_ai_tools_api.pkb
@@ -989,10 +989,7 @@ create or replace package body uc_ai_tools_api as
   end create_parameters_recursive;
 
   /*
-   * Creates or updates a tool definition from a JSON schema
-   * 
-   * If a tool with the same code already exists, it will be updated.
-   * Parameters and tags are replaced (deleted and recreated) on update.
+   * Creates a new tool definition from a JSON schema
    */
   function create_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,
@@ -1007,7 +1004,122 @@ create or replace package body uc_ai_tools_api as
   ) return uc_ai_tools.id%type
   as
     l_scope uc_ai_logger.scope := gc_scope_prefix || 'create_tool_from_schema';
-    
+
+    l_tool_id uc_ai_tools.id%type;
+    l_properties json_object_t;
+    l_required_arr json_array_t;
+    l_required_keys_arr json_key_list := json_key_list();
+    l_schema_clob clob;
+  begin
+    uc_ai_logger.log('Creating tool from schema', l_scope, 'Tool: ' || p_tool_code);
+
+    l_schema_clob := case when p_json_schema is not null then p_json_schema.to_clob else null end;
+
+    -- Create the tool record
+    insert into uc_ai_tools (
+      code,
+      description,
+      active,
+      response_schema,
+      version,
+      function_call,
+      authorization_schema,
+      created_by,
+      created_at,
+      updated_by,
+      updated_at
+    ) values (
+      p_tool_code,
+      p_description,
+      p_active,
+      l_schema_clob, -- Store the original schema for reference
+      p_version,
+      p_function_call,
+      p_authorization_schema,
+      p_created_by,
+      systimestamp,
+      p_created_by,
+      systimestamp
+    ) returning id into l_tool_id;
+
+    uc_ai_logger.log('Created tool with ID: ' || l_tool_id, l_scope);
+
+    if l_schema_clob is null then
+      return l_tool_id;
+    end if;
+
+    -- Extract properties and required array from schema
+    l_properties := treat(p_json_schema.get('properties') as json_object_t);
+    l_required_arr := treat(p_json_schema.get('required') as json_array_t);
+
+    -- Convert required array to key list for easier processing
+    if l_required_arr is not null then
+      <<required_loop>>
+      for i in 0 .. l_required_arr.get_size - 1 loop
+        l_required_keys_arr.extend;
+        l_required_keys_arr(l_required_keys_arr.count) := l_required_arr.get_string(i);
+      end loop required_loop;
+    end if;
+
+    -- Create parameters from schema properties
+    create_parameters_recursive(
+      p_properties => l_properties
+    , p_required_keys => l_required_keys_arr
+    , p_parent_param_id => null
+    , p_created_by => p_created_by
+    , p_tool_id => l_tool_id
+    );
+
+    -- Create tags if provided
+    if p_tags is not null and p_tags.count > 0 then
+      forall i in 1 .. p_tags.count
+        insert into uc_ai_tool_tags (
+          tool_id,
+          tag_name,
+          created_by,
+          created_at,
+          updated_by,
+          updated_at
+        ) values (
+          l_tool_id,
+          lower(p_tags(i)),
+          p_created_by,
+          systimestamp,
+          p_created_by,
+          systimestamp
+        );
+    end if;
+
+    uc_ai_logger.log('Successfully created tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
+
+    return l_tool_id;
+
+  exception
+    when others then
+      uc_ai_logger.log_error('Error in create_tool_from_schema', l_scope, sqlerrm || ' ' || sys.dbms_utility.format_error_backtrace);
+      raise;
+  end create_tool_from_schema;
+
+  /*
+   * Creates or updates a tool definition from a JSON schema
+   *
+   * If a tool with the same code already exists, it will be updated.
+   * Parameters and tags are replaced (deleted and recreated) on update.
+   */
+  function merge_tool_from_schema(
+    p_tool_code             in uc_ai_tools.code%type,
+    p_description           in uc_ai_tools.description%type,
+    p_function_call         in uc_ai_tools.function_call%type,
+    p_json_schema           in json_object_t,
+    p_active                in uc_ai_tools.active%type default 1,
+    p_version               in uc_ai_tools.version%type default '1.0',
+    p_authorization_schema  in uc_ai_tools.authorization_schema%type default null,
+    p_created_by            in uc_ai_tools.created_by%type default coalesce(sys_context('APEX$SESSION','app_user'), sys_context('userenv', 'session_user')),
+    p_tags                  in apex_t_varchar2 default apex_t_varchar2()
+  ) return uc_ai_tools.id%type
+  as
+    l_scope uc_ai_logger.scope := gc_scope_prefix || 'merge_tool_from_schema';
+
     l_tool_id uc_ai_tools.id%type;
     l_existing_tool_id uc_ai_tools.id%type;
     l_properties json_object_t;
@@ -1015,7 +1127,7 @@ create or replace package body uc_ai_tools_api as
     l_required_keys_arr json_key_list := json_key_list();
     l_schema_clob clob;
   begin
-    uc_ai_logger.log('Creating/updating tool from schema', l_scope, 'Tool: ' || p_tool_code);
+    uc_ai_logger.log('Merging tool from schema', l_scope, 'Tool: ' || p_tool_code);
 
     l_schema_clob := case when p_json_schema is not null then p_json_schema.to_clob else null end;
 
@@ -1042,15 +1154,15 @@ create or replace package body uc_ai_tools_api as
              updated_by           = p_created_by,
              updated_at           = systimestamp
        where id = l_existing_tool_id;
-      
+
       l_tool_id := l_existing_tool_id;
-      
+
       uc_ai_logger.log('Updated existing tool with ID: ' || l_tool_id, l_scope);
-      
+
       -- Delete existing parameters (cascade will handle nested params)
       delete from uc_ai_tool_parameters
        where tool_id = l_tool_id;
-      
+
       -- Delete existing tags
       delete from uc_ai_tool_tags
        where tool_id = l_tool_id;
@@ -1072,7 +1184,7 @@ create or replace package body uc_ai_tools_api as
         p_tool_code,
         p_description,
         p_active,
-        l_schema_clob, -- Store the original schema for reference
+        l_schema_clob,
         p_version,
         p_function_call,
         p_authorization_schema,
@@ -1081,18 +1193,18 @@ create or replace package body uc_ai_tools_api as
         p_created_by,
         systimestamp
       ) returning id into l_tool_id;
-      
+
       uc_ai_logger.log('Created new tool with ID: ' || l_tool_id, l_scope);
     end if;
 
     if l_schema_clob is null then
       return l_tool_id;
     end if;
-    
+
     -- Extract properties and required array from schema
     l_properties := treat(p_json_schema.get('properties') as json_object_t);
     l_required_arr := treat(p_json_schema.get('required') as json_array_t);
-    
+
     -- Convert required array to key list for easier processing
     if l_required_arr is not null then
       <<required_loop>>
@@ -1101,7 +1213,7 @@ create or replace package body uc_ai_tools_api as
         l_required_keys_arr(l_required_keys_arr.count) := l_required_arr.get_string(i);
       end loop required_loop;
     end if;
-    
+
     -- Create parameters from schema properties
     create_parameters_recursive(
       p_properties => l_properties
@@ -1110,7 +1222,7 @@ create or replace package body uc_ai_tools_api as
     , p_created_by => p_created_by
     , p_tool_id => l_tool_id
     );
-    
+
     -- Create tags if provided
     if p_tags is not null and p_tags.count > 0 then
       forall i in 1 .. p_tags.count
@@ -1130,16 +1242,16 @@ create or replace package body uc_ai_tools_api as
           systimestamp
         );
     end if;
-    
-    uc_ai_logger.log('Successfully created/updated tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
-    
+
+    uc_ai_logger.log('Successfully merged tool with schema', l_scope, 'Tool ID: ' || l_tool_id);
+
     return l_tool_id;
-    
+
   exception
     when others then
-      uc_ai_logger.log_error('Error in create_tool_from_schema', l_scope, sqlerrm || ' ' || sys.dbms_utility.format_error_backtrace);
+      uc_ai_logger.log_error('Error in merge_tool_from_schema', l_scope, sqlerrm || ' ' || sys.dbms_utility.format_error_backtrace);
       raise;
-  end create_tool_from_schema;
+  end merge_tool_from_schema;
 
 end uc_ai_tools_api;
 /

--- a/src/packages/uc_ai_tools_api.pkb
+++ b/src/packages/uc_ai_tools_api.pkb
@@ -601,8 +601,12 @@ create or replace package body uc_ai_tools_api as
         l_bind_list(1) := l_bind;
         uc_ai_logger.log('Bind variable found', l_scope, l_bind.name || ' = ' || l_bind.value);
       else
-        uc_ai_logger.log_error('Error in execute_tool: %s', 'Multiple bind variables found in tool fc code: ' || apex_string.join(l_found_binds, ', '), l_scope);
-        raise_application_error(-20001, 'You are only allowed to set one parameter bind. Multiple bind variables found in tool fc code: ' || apex_string.join(l_found_binds, ', '));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_invalid_config
+        , p_scope      => l_scope
+        , p0           => 'tool function call'
+        , p1           => 'Multiple bind variables found: ' || apex_string.join(l_found_binds, ', ') || '. Only one parameter bind is allowed.'
+        );
       end if;
 
       uc_ai_logger.log('Executing tool', l_scope, l_fc_code);
@@ -618,8 +622,12 @@ create or replace package body uc_ai_tools_api as
       uc_ai_logger.log('Tool execution result', l_scope, l_return);
 
       if l_return is null then
-        uc_ai_logger.log_error('Error in execute_tool: %s', 'Tool execution returned NULL', l_scope);
-        raise_application_error(-20001, 'Tool execution returned NULL');
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_invalid_config
+        , p_scope      => l_scope
+        , p0           => 'tool execution'
+        , p1           => 'Tool execution returned NULL for tool code ' || p_tool_code
+        );
       end if;
 
       return l_return;
@@ -681,8 +689,12 @@ create or replace package body uc_ai_tools_api as
         l_return := l_clob;
 
       else
-        uc_ai_logger.log_error('Error in execute_tool: %s', 'Multiple bind variables found in tool fc code: ' || apex_string.join(l_found_binds, ', '), l_scope);
-        raise_application_error(-20001, 'You are only allowed to set one parameter bind. Multiple bind variables found in tool fc code: ' || apex_string.join(l_found_binds, ', '));
+        uc_ai_error.raise_error(
+          p_error_code => uc_ai_error.c_err_invalid_config
+        , p_scope      => l_scope
+        , p0           => 'tool function call'
+        , p1           => 'Multiple bind variables found: ' || apex_string.join(l_found_binds, ', ') || '. Only one parameter bind is allowed.'
+        );
       end if;
     end if;
 

--- a/src/packages/uc_ai_tools_api.pks
+++ b/src/packages/uc_ai_tools_api.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_tools_api as
+create or replace package uc_ai_tools_api 
+  authid definer
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_tools_api.pks
+++ b/src/packages/uc_ai_tools_api.pks
@@ -44,10 +44,12 @@ create or replace package uc_ai_tools_api as
   ) return uc_ai_tool_parameters.name%type result_cache;
 
   /*
-   * Creates a new tool definition from a JSON schema
+   * Creates or updates a tool definition from a JSON schema
    * 
-   * Takes a JSON schema input and creates the corresponding records in
-   * uc_ai_tools and uc_ai_tool_parameters tables.
+   * Takes a JSON schema input and creates or updates the corresponding records in
+   * uc_ai_tools, uc_ai_tool_parameters, and uc_ai_tool_tags tables.
+   * If a tool with the same code already exists, it will be updated and its
+   * parameters and tags will be replaced.
    * 
    * @param p_tool_code          Unique code for the tool
    * @param p_description        Description of what the tool does
@@ -59,7 +61,7 @@ create or replace package uc_ai_tools_api as
    * @param p_created_by         User creating the tool
    * @param p_tags               Array of tags to associate with the tool
    * 
-   * @return tool_id             The ID of the created tool
+   * @return tool_id             The ID of the created or updated tool
    */
   function create_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,

--- a/src/packages/uc_ai_tools_api.pks
+++ b/src/packages/uc_ai_tools_api.pks
@@ -46,10 +46,12 @@ as
   ) return uc_ai_tool_parameters.name%type result_cache;
 
   /*
-   * Creates a new tool definition from a JSON schema
+   * Creates or updates a tool definition from a JSON schema
    * 
-   * Takes a JSON schema input and creates the corresponding records in
-   * uc_ai_tools and uc_ai_tool_parameters tables.
+   * Takes a JSON schema input and creates or updates the corresponding records in
+   * uc_ai_tools, uc_ai_tool_parameters, and uc_ai_tool_tags tables.
+   * If a tool with the same code already exists, it will be updated and its
+   * parameters and tags will be replaced.
    * 
    * @param p_tool_code          Unique code for the tool
    * @param p_description        Description of what the tool does
@@ -61,7 +63,7 @@ as
    * @param p_created_by         User creating the tool
    * @param p_tags               Array of tags to associate with the tool
    * 
-   * @return tool_id             The ID of the created tool
+   * @return tool_id             The ID of the created or updated tool
    */
   function create_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,

--- a/src/packages/uc_ai_tools_api.pks
+++ b/src/packages/uc_ai_tools_api.pks
@@ -46,13 +46,11 @@ as
   ) return uc_ai_tool_parameters.name%type result_cache;
 
   /*
-   * Creates or updates a tool definition from a JSON schema
-   * 
-   * Takes a JSON schema input and creates or updates the corresponding records in
-   * uc_ai_tools, uc_ai_tool_parameters, and uc_ai_tool_tags tables.
-   * If a tool with the same code already exists, it will be updated and its
-   * parameters and tags will be replaced.
-   * 
+   * Creates a new tool definition from a JSON schema
+   *
+   * Takes a JSON schema input and creates the corresponding records in
+   * uc_ai_tools and uc_ai_tool_parameters tables.
+   *
    * @param p_tool_code          Unique code for the tool
    * @param p_description        Description of what the tool does
    * @param p_function_call      PL/SQL function that executes the tool
@@ -62,10 +60,42 @@ as
    * @param p_authorization_schema Authorization schema if needed
    * @param p_created_by         User creating the tool
    * @param p_tags               Array of tags to associate with the tool
-   * 
-   * @return tool_id             The ID of the created or updated tool
+   *
+   * @return tool_id             The ID of the created tool
    */
   function create_tool_from_schema(
+    p_tool_code             in uc_ai_tools.code%type,
+    p_description           in uc_ai_tools.description%type,
+    p_function_call         in uc_ai_tools.function_call%type,
+    p_json_schema           in json_object_t,
+    p_active                in uc_ai_tools.active%type default 1,
+    p_version               in uc_ai_tools.version%type default '1.0',
+    p_authorization_schema  in uc_ai_tools.authorization_schema%type default null,
+    p_created_by            in uc_ai_tools.created_by%type default coalesce(sys_context('APEX$SESSION','app_user'), sys_context('userenv', 'session_user')),
+    p_tags                  in apex_t_varchar2 default apex_t_varchar2()
+  ) return uc_ai_tools.id%type;
+
+  /*
+   * Creates or updates a tool definition from a JSON schema
+   *
+   * Takes a JSON schema input and creates or updates the corresponding records in
+   * uc_ai_tools, uc_ai_tool_parameters, and uc_ai_tool_tags tables.
+   * If a tool with the same code already exists, it will be updated and its
+   * parameters and tags will be replaced.
+   *
+   * @param p_tool_code          Unique code for the tool
+   * @param p_description        Description of what the tool does
+   * @param p_function_call      PL/SQL function that executes the tool
+   * @param p_json_schema        JSON schema defining the tool parameters
+   * @param p_active             Whether the tool is active (default 1)
+   * @param p_version            Tool version (default '1.0')
+   * @param p_authorization_schema Authorization schema if needed
+   * @param p_created_by         User creating the tool
+   * @param p_tags               Array of tags to associate with the tool
+   *
+   * @return tool_id             The ID of the created or updated tool
+   */
+  function merge_tool_from_schema(
     p_tool_code             in uc_ai_tools.code%type,
     p_description           in uc_ai_tools.description%type,
     p_function_call         in uc_ai_tools.function_call%type,

--- a/src/packages/uc_ai_toon.pks
+++ b/src/packages/uc_ai_toon.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_toon authid current_user as
+create or replace package uc_ai_toon 
+  authid definer 
+as
 
   /**
   * UC AI

--- a/src/packages/uc_ai_xai.pks
+++ b/src/packages/uc_ai_xai.pks
@@ -1,4 +1,6 @@
-create or replace package uc_ai_xai as
+create or replace package uc_ai_xai 
+  authid definer
+as
   -- @dblinter ignore(g-7230): allow use of global variables
 
   /**

--- a/src/triggers/triggers.sql
+++ b/src/triggers/triggers.sql
@@ -72,3 +72,11 @@ begin
     :new.updated_by := coalesce(sys_context('APEX$SESSION', 'APP_USER'), user);
 end uc_ai_agents_biu;
 /
+
+create or replace trigger uc_ai_agent_executions_bi
+    before insert on uc_ai_agent_executions
+    for each row
+begin
+    :new.started_at := systimestamp;
+end uc_ai_agent_executions_bi;
+/

--- a/test/test_uc_ai_anthropic.pkb
+++ b/test/test_uc_ai_anthropic.pkb
@@ -262,6 +262,75 @@ create or replace package body test_uc_ai_anthropic as
   end image_file_input;
 
 
+  procedure reasoning_with_tools
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+    l_assistant_message json_object_t;
+    l_assistant_content json_array_t;
+    l_content json_object_t;
+    l_reasoning_message_found boolean := false;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+
+    uc_ai.g_enable_tools := true;
+    uc_ai.g_enable_reasoning := true;
+    uc_ai_anthropic.g_reasoning_budget_tokens := 1024;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'What is the email address of Jim?',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
+      p_provider => uc_ai.c_provider_anthropic,
+      p_model => uc_ai_anthropic.c_model_claude_4_sonnet
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    -- Check that reasoning content is present in at least one assistant message
+    <<message_loop>>
+    for i in 0 .. l_messages.get_size - 1
+    loop
+      l_assistant_message := treat(l_messages.get(i) as json_object_t);
+      if l_assistant_message.get_string('role') = 'assistant' then
+        l_assistant_content := l_assistant_message.get_array('content');
+        <<content_loop>>
+        for j in 0 .. l_assistant_content.get_size - 1
+        loop
+          l_content := treat(l_assistant_content.get(j) as json_object_t);
+          if l_content.get_string('type') = 'reasoning' then
+            sys.dbms_output.put_line('Reasoning content: ' || l_content.get_clob('text'));
+            l_reasoning_message_found := true;
+          end if;
+        end loop content_loop;
+      end if;
+    end loop message_loop;
+
+    ut.expect(l_reasoning_message_found, 'No reasoning message found in response').to_equal(true);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Reasoning with Tools Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+  end reasoning_with_tools;
+
+
   procedure reasoning
   as
     l_messages json_array_t := json_array_t();

--- a/test/test_uc_ai_anthropic.pks
+++ b/test/test_uc_ai_anthropic.pks
@@ -23,6 +23,9 @@ create or replace package test_uc_ai_anthropic as
   --%test(image file input)
   procedure image_file_input;
 
+  --%test(reasoning with tools)
+  procedure reasoning_with_tools;
+
   --%test(reasoning)
   procedure reasoning;
 

--- a/test/test_uc_ai_google.pkb
+++ b/test/test_uc_ai_google.pkb
@@ -258,6 +258,75 @@ create or replace package body test_uc_ai_google as
   end image_file_input;
 
 
+  procedure reasoning_with_tools
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+    l_assistant_message json_object_t;
+    l_assistant_content json_array_t;
+    l_content json_object_t;
+    l_reasoning_message_found boolean := false;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+
+    uc_ai.g_enable_tools := true;
+    uc_ai.g_enable_reasoning := true;
+    uc_ai_google.g_reasoning_budget := 512;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'What is the email address of Jim?',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
+      p_provider => uc_ai.c_provider_google,
+      p_model => uc_ai_google.c_model_gemini_2_5_flash
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    -- Check that reasoning content is present in at least one assistant message
+    <<message_loop>>
+    for i in 0 .. l_messages.get_size - 1
+    loop
+      l_assistant_message := treat(l_messages.get(i) as json_object_t);
+      if l_assistant_message.get_string('role') = 'assistant' then
+        l_assistant_content := l_assistant_message.get_array('content');
+        <<content_loop>>
+        for j in 0 .. l_assistant_content.get_size - 1
+        loop
+          l_content := treat(l_assistant_content.get(j) as json_object_t);
+          if l_content.get_string('type') = 'reasoning' then
+            sys.dbms_output.put_line('Reasoning content: ' || l_content.get_clob('text'));
+            l_reasoning_message_found := true;
+          end if;
+        end loop content_loop;
+      end if;
+    end loop message_loop;
+
+    ut.expect(l_reasoning_message_found, 'No reasoning message found in response').to_equal(true);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Reasoning with Tools Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+  end reasoning_with_tools;
+
+
   procedure reasoning
   as
     l_messages json_array_t := json_array_t();

--- a/test/test_uc_ai_google.pks
+++ b/test/test_uc_ai_google.pks
@@ -20,6 +20,9 @@ create or replace package test_uc_ai_google as
   --%test(image file input)
   procedure image_file_input;
 
+  --%test(reasoning with tools)
+  procedure reasoning_with_tools;
+
   --%test(reasoning)
   procedure reasoning;
 

--- a/test/test_uc_ai_oci.pkb
+++ b/test/test_uc_ai_oci.pkb
@@ -37,6 +37,217 @@ create or replace package body test_uc_ai_oci as
   end basic_recipe_generic;
 
 
+  procedure basic_recipe_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+  begin
+    uc_ai_oci.g_compartment_id := get_oci_compratment_id;
+    uc_ai_oci.g_region := 'eu-frankfurt-1';
+    uc_ai_oci.g_apex_web_credential := 'OCI_KEY';
+    uc_ai_oci.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'I have tomatoes, salad, potatoes, olives, and cheese. What can I cook with that?',
+      p_system_prompt => 'You are an assistant helping users to get recipes. Please answer in short sentences.',
+      p_provider => uc_ai.c_provider_oci,
+      p_model => 'google.gemini-2.5-flash'
+    );
+
+    l_final_message := l_result.get_clob('final_message');
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_equal(3); -- system message + user message + assistant response
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.valididate_return_object(l_result, 'Basic recipe Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    uc_ai_oci.g_use_responses_api := false;
+  end basic_recipe_responses_api;
+
+
+  procedure continue_conv_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_content json_array_t := json_array_t();
+  begin
+    uc_ai_oci.g_compartment_id := get_oci_compratment_id;
+    uc_ai_oci.g_region := 'eu-frankfurt-1';
+    uc_ai_oci.g_apex_web_credential := 'OCI_KEY';
+    uc_ai_oci.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_system_prompt => 'Let''s count up',
+      p_user_prompt => '1',
+      p_provider => uc_ai.c_provider_oci,
+      p_model => 'google.gemini-2.5-flash'
+    );
+
+    l_final_message := l_result.get_clob('final_message');
+    ut.expect(l_final_message).to_be_like('%2%');
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_equal(3); -- system message + user message + assistant response
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Continue Conversation Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    l_content.append(uc_ai_message_api.create_text_content(
+      '3'
+    ));
+
+    l_messages.append(
+      uc_ai_message_api.create_user_message(l_content)
+    );
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_messages => l_messages,
+      p_provider => uc_ai.c_provider_oci,
+      p_model => 'google.gemini-2.5-flash'
+    );
+
+    l_final_message := l_result.get_clob('final_message');
+    ut.expect(l_final_message).to_be_like('%4%');
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_equal(5); -- system message + (user message + assistant response) * 2
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Continue Conversation Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    uc_ai_oci.g_use_responses_api := false;
+  end continue_conv_responses_api;
+
+
+  procedure tool_user_info_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+
+    uc_ai.g_enable_tools := true;
+    uc_ai_oci.g_compartment_id := get_oci_compratment_id;
+    uc_ai_oci.g_region := 'eu-frankfurt-1';
+    uc_ai_oci.g_apex_web_credential := 'OCI_KEY';
+    uc_ai_oci.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'What is the email address of Jim?',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
+      p_provider => uc_ai.c_provider_oci,
+      p_model => 'openai.gpt-oss-120b'
+    );
+
+    l_final_message := l_result.get_clob('final_message');
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool User Info Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    uc_ai_oci.g_use_responses_api := false;
+  end tool_user_info_responses_api;
+
+
+  procedure tool_clock_in_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+
+    l_user_id number;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+    uc_ai_test_utils.add_get_projects_tool();
+    uc_ai_test_utils.add_clock_tools();
+
+    -- delete all time entries for Michael Scott (to avoid error "already clocked in")
+    select user_id into l_user_id from TT_USERS where email = 'michael.scott@dundermifflin.com';
+    delete from TT_TIME_ENTRIES where user_id = l_user_id;
+
+    uc_ai.g_enable_tools := true;
+    uc_ai_oci.g_compartment_id := get_oci_compratment_id;
+    uc_ai_oci.g_region := 'eu-frankfurt-1';
+    uc_ai_oci.g_apex_web_credential := 'OCI_KEY';
+    uc_ai_oci.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'Please clock me in to the marketing project with the note "meeting".',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.
+        The current user is Michael Scott. Make sure to double check if inputs like user or project are correct.
+
+        If you clock somebody in, answer with: "You are now clocked in to the project "{{project_name}}" with the note "{{notes| - }}".',
+      p_provider => uc_ai.c_provider_oci,
+      p_model => 'openai.gpt-oss-120b'
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool Clock in user Responses API Test');
+
+    uc_ai_oci.g_use_responses_api := false;
+  end tool_clock_in_responses_api;
+
+
   procedure continue_conversation_generic
   as
     l_result json_object_t;

--- a/test/test_uc_ai_oci.pks
+++ b/test/test_uc_ai_oci.pks
@@ -5,6 +5,9 @@ create or replace package test_uc_ai_oci as
   --%test(Basic recipe generation with OCI in Generic Mode)
   procedure basic_recipe_generic;
 
+  --%test(Basic recipe generation with OCI using Responses API)
+  procedure basic_recipe_responses_api;
+
   --%test(Continue conversations with OCI in Generic Mode)
   procedure continue_conversation_generic;
 
@@ -16,6 +19,15 @@ create or replace package test_uc_ai_oci as
 
   --%test(Tool usage - clock in user in Generic Mode with GPT OSS)
   procedure tool_clock_in_user_gpt_oss;
+
+  --%test(Continue conversations with OCI using Responses API)
+  procedure continue_conv_responses_api;
+
+  --%test(Tool usage - get user info using Responses API)
+  procedure tool_user_info_responses_api;
+
+  --%test(Tool usage - clock in user using Responses API)
+  procedure tool_clock_in_responses_api;
 
   --%test(Basic recipe generation with OCI in Cohere Mode)
   procedure basic_recipe_cohere;

--- a/test/test_uc_ai_ollama.pkb
+++ b/test/test_uc_ai_ollama.pkb
@@ -2,30 +2,33 @@ create or replace package body test_uc_ai_ollama as
   -- @dblinter ignore(g-5010): allow logger in test packages
   -- @dblinter ignore(g-2160): allow initialzing variables in declare in test packages
 
-  c_model_qwen_1b constant uc_ai.model_type := 'qwen3:1.7b';
-  c_model_qwen_4b constant uc_ai.model_type := 'qwen3:4b';
-  c_model_gemma3_4b constant uc_ai.model_type := 'gemma3:4b';
-  c_model_gpt_oss constant uc_ai.model_type := 'gpt-oss:20b';
+  c_model constant uc_ai.model_type := 'gemma4:26b';
+  c_base_url constant varchar2(255 char) := 'https://ai.united-codes.com/api';
+  c_web_credential constant varchar2(255 char) := 'OLLAMA';
 
-  procedure basic_recipe (
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  )
+  procedure setup_ollama
+  as
+  begin
+    uc_ai.g_base_url := c_base_url;
+    uc_ai.g_apex_web_credential := c_web_credential;
+    uc_ai.g_enable_reasoning := false;
+  end setup_ollama;
+
+  procedure basic_recipe
   as
     l_result json_object_t;
     l_final_message clob;
     l_messages json_array_t;
     l_message_count pls_integer;
   begin
-    uc_ai.g_base_url := p_base_url;
-    uc_ai.g_enable_reasoning := p_reasoning_enabled;
+    setup_ollama;
     uc_ai.g_enable_tools := false;
+
     l_result := uc_ai.GENERATE_TEXT(
       p_user_prompt => 'I have tomatoes, salad, potatoes, olives, and cheese. What can I cook with that?',
-      p_system_prompt => 'You are an assistant helping users to get recipes. Please just list 3 possible dishe names without instructions.',
+      p_system_prompt => 'You are an assistant helping users to get recipes. Please just list 3 possible dish names without instructions.',
       p_provider => uc_ai.c_provider_ollama,
-      p_model => p_model
+      p_model => c_model
     );
 
     sys.dbms_output.put_line('Result: ' || l_result.to_string);
@@ -43,11 +46,7 @@ create or replace package body test_uc_ai_ollama as
     ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
   end basic_recipe;
 
-  procedure tool_user_info(
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  )
+  procedure tool_user_info
   as
     l_result json_object_t;
     l_final_message clob;
@@ -59,17 +58,15 @@ create or replace package body test_uc_ai_ollama as
     delete from UC_AI_TOOLS where 1 = 1;
     uc_ai_test_utils.add_get_users_tool();
 
-    uc_ai.g_base_url := p_base_url;
-    uc_ai.g_enable_reasoning := p_reasoning_enabled;
+    setup_ollama;
     uc_ai.g_enable_tools := true;
 
     l_result := uc_ai.GENERATE_TEXT(
       p_user_prompt => 'What is the email address of Jim?',
       p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
       p_provider => uc_ai.c_provider_ollama,
-      p_model => p_model
+      p_model => c_model
     );
-    logger.log('UC AI result', 'Tool User Info Test ', l_result.to_string);
 
     l_final_message := l_result.get_clob('final_message');
     ut.expect(l_final_message).to_be_not_null();
@@ -84,18 +81,14 @@ create or replace package body test_uc_ai_ollama as
     sys.dbms_output.put_line('Result: ' || l_result.to_string);
     sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
     sys.dbms_output.put_line('Last message: ' || l_final_message);
-  
-   -- Validate message array structure against spec
+
+    -- Validate message array structure against spec
     uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool User Info Test');
 
     ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
   end tool_user_info;
 
-  procedure tool_clock_in_user(
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  )
+  procedure tool_clock_in_user
   as
     l_result json_object_t;
     l_final_message clob;
@@ -115,28 +108,96 @@ create or replace package body test_uc_ai_ollama as
     select user_id into l_user_id from TT_USERS where email = 'michael.scott@dundermifflin.com';
     delete from TT_TIME_ENTRIES where user_id = l_user_id;
 
-    uc_ai.g_base_url := p_base_url;
-    uc_ai.g_enable_reasoning := p_reasoning_enabled;
+    setup_ollama;
     uc_ai.g_enable_tools := true;
 
     l_result := uc_ai.GENERATE_TEXT(
       p_user_prompt => 'Please clock me in to the marketing project with the note "meeting".',
       p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user and project information. You can also clock in a user. Make sure to validate the user and project before clocking in.
-        
+
         The current user is Michael Scott.',
       p_provider => uc_ai.c_provider_ollama,
-      p_model => p_model
+      p_model => c_model
     );
-    logger.log('UC AI result', 'Tool Clock In User Test ', l_result.to_string);
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
 
     l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
 
-    -- most likely the model will just give up; in this case l_final_message will be null
-    if l_final_message is null then
-      sys.dbms_output.put_line('No final message returned, assuming model gave up.');
-    end if;
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
 
-    --ut.expect(l_final_message).to_be_not_null();
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool Clock In User Test');
+  end tool_clock_in_user;
+
+  procedure basic_recipe_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+  begin
+    setup_ollama;
+    uc_ai.g_enable_tools := false;
+    uc_ai_ollama.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'I have tomatoes, salad, potatoes, olives, and cheese. What can I cook with that?',
+      p_system_prompt => 'You are an assistant helping users to get recipes. Please just list 3 possible dish names without instructions.',
+      p_provider => uc_ai.c_provider_ollama,
+      p_model => c_model
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_equal(3); -- System, user, assistant message
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.valididate_return_object(p_response => l_result, p_test_name => 'Basic recipe Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    uc_ai_ollama.g_use_responses_api := false;
+  end basic_recipe_responses_api;
+
+  procedure tool_user_info_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+
+    setup_ollama;
+    uc_ai.g_enable_tools := true;
+    uc_ai_ollama.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'What is the email address of Jim?',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
+      p_provider => uc_ai.c_provider_ollama,
+      p_model => c_model
+    );
+
+    l_final_message := l_result.get_clob('final_message');
+    ut.expect(l_final_message).to_be_not_null();
 
     l_messages := treat(l_result.get('messages') as json_array_t);
     l_message_count := l_messages.get_size;
@@ -149,9 +210,66 @@ create or replace package body test_uc_ai_ollama as
     sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
     sys.dbms_output.put_line('Last message: ' || l_final_message);
 
-   -- Validate message array structure against spec
-    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool Clock In User Test');
-  end tool_clock_in_user;
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool User Info Responses API Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+
+    uc_ai_ollama.g_use_responses_api := false;
+  end tool_user_info_responses_api;
+
+  procedure tool_clock_in_responses_api
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+
+    l_user_id number;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+    uc_ai_test_utils.add_get_projects_tool();
+    uc_ai_test_utils.add_clock_tools();
+
+    -- delete all time entries for Michael Scott (to avoid error "already clocked in")
+    select user_id into l_user_id from TT_USERS where email = 'michael.scott@dundermifflin.com';
+    delete from TT_TIME_ENTRIES where user_id = l_user_id;
+
+    setup_ollama;
+    uc_ai.g_enable_tools := true;
+    uc_ai_ollama.g_use_responses_api := true;
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'Please clock me in to the marketing project with the note "meeting".',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user and project information. You can also clock in a user. Make sure to validate the user and project before clocking in.
+
+        The current user is Michael Scott.',
+      p_provider => uc_ai.c_provider_ollama,
+      p_model => c_model
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Tool Clock In User Responses API Test');
+
+    uc_ai_ollama.g_use_responses_api := false;
+  end tool_clock_in_responses_api;
 
   procedure convert_messages
   as
@@ -165,245 +283,23 @@ create or replace package body test_uc_ai_ollama as
     ut.expect(l_result.get_size).to_be_greater_than(0);
   end convert_messages;
 
-  -- Test procedures for specific models
-  procedure basic_recipe_qwen_1b
-  as
-  begin
-    basic_recipe(p_model => c_model_qwen_1b);
-  end basic_recipe_qwen_1b;
-
-  procedure basic_recipe_gemma_4b
-  as
-  begin
-    basic_recipe(p_model => c_model_gemma3_4b, p_reasoning_enabled => false);
-  end basic_recipe_gemma_4b;
-
-  procedure basic_recipe_gpt_oss
-  as
-  begin
-    basic_recipe(p_model => c_model_gpt_oss, p_reasoning_enabled => false);
-  end basic_recipe_gpt_oss;
-
-
-  procedure tool_user_info_qwen_4b
-  as
-  begin
-    tool_user_info(p_model => c_model_qwen_4b);
-  end tool_user_info_qwen_4b;
-
-  procedure tool_user_info_gpt_oss
-  as
-  begin
-    tool_user_info(p_model => c_model_gpt_oss);
-  end tool_user_info_gpt_oss;
-
-  procedure tool_clock_in_user_qwen_4b
-  as
-  begin
-    tool_clock_in_user(p_model => c_model_qwen_4b);
-  end tool_clock_in_user_qwen_4b;
-
-  procedure tool_clock_in_user_gpt_oss
-  as
-  begin
-    tool_clock_in_user(p_model => c_model_gpt_oss);
-  end tool_clock_in_user_gpt_oss;
-
-  procedure image_file_input_gemma_4b
-  as
-    l_messages json_array_t := json_array_t();
-    l_content json_array_t := json_array_t();
-    l_result json_object_t;
-    l_res_clob clob;
-    l_final_message clob;
-  begin
-    l_messages.append(uc_ai_message_api.create_system_message(
-      'You are an image analysis assistant.'));
-
-    l_content.append(uc_ai_message_api.create_file_content(
-      p_media_type => 'image/webp',
-      p_data_blob => uc_ai_test_utils.get_apple_webp,
-      p_filename => 'data.webp'
-    ));
-
-    l_content.append(uc_ai_message_api.create_text_content(
-      'What is the fruit depicted in the attached image?'
-    ));
-
-    l_messages.append(uc_ai_message_api.create_user_message(l_content));
-    
-
-    -- Validate message array structure against spec
-    uc_ai_test_message_utils.validate_message_array(l_messages, 'Image file input before');
-
-    uc_ai.g_base_url := 'host.containers.internal:11434/api';
-    uc_ai.g_enable_tools := false; -- disable tools for this test
-    uc_ai.g_enable_reasoning := false; -- disable reasoning for this test
-
-    l_result := uc_ai.generate_text(
-      p_messages => l_messages,
-      p_provider => uc_ai.c_provider_ollama,
-      p_model => c_model_gemma3_4b
-    );
-
-    l_res_clob := l_result.to_clob;
-    logger.log_info(p_text => 'Image file input result:', p_extra => l_res_clob);
-
-    l_final_message := l_result.get_clob('final_message');
-    sys.dbms_output.put_line('Last message: ' || l_final_message);
-    ut.expect(lower(l_final_message)).to_be_like('%apple%');
-
-    -- Validate message array structure against spec
-    uc_ai_test_message_utils.validate_message_array(l_messages, 'Image file input response');
-
-    sys.dbms_output.put_line('Result: ' || l_result.to_string);
-  end image_file_input_gemma_4b;
-
-
-  procedure reasoning
-  as
-    l_messages json_array_t := json_array_t();
-    l_result json_object_t;
-    l_message_count pls_integer;
-    l_final_message clob;
-    l_second_message json_object_t;
-    l_second_message_content json_array_t;
-    l_content json_object_t;
-    l_reasoning_message_found boolean := false;
-  begin
-    uc_ai.g_base_url := 'host.containers.internal:11434/api';
-    uc_ai.g_enable_tools := false; -- disable tools for this test
-    uc_ai.g_enable_reasoning := true; -- enable reasoning for this test
-
-    l_result := uc_ai.GENERATE_TEXT(
-      p_user_prompt => 'Answer in one sentence. If there is a great filter, are we before or after it and why.',
-      p_provider => uc_ai.c_provider_ollama,
-      p_model => c_model_qwen_4b
-    );
-
-    sys.dbms_output.put_line('Result: ' || l_result.to_string);
-
-    l_final_message := l_result.get_clob('final_message');
-    sys.dbms_output.put_line('Last message: ' || l_final_message);
-    ut.expect(lower(l_final_message)).to_be_like('%filter%');
-
-    l_messages := treat(l_result.get('messages') as json_array_t);
-    uc_ai_test_message_utils.validate_message_array(l_messages, 'Reasoning response');
-    l_message_count := l_messages.get_size;
-    -- One user message and one assistant message are expected
-    ut.expect(l_message_count).to_equal(2);
-
-    l_second_message := treat(l_messages.get(1) as json_object_t);
-    ut.expect(l_second_message.get_string('role')).to_equal('assistant');
-
-    l_second_message_content := l_second_message.get_array('content');
-    ut.expect(l_second_message_content.get_size).to_equal(2);
-
-    <<assistant_content_loop>>
-    for i in 0 .. l_second_message_content.get_size - 1 
-    loop
-      l_content := treat(l_second_message_content.get(i) as json_object_t);
-      case l_content.get_string('type')
-         when 'reasoning' then
-            sys.dbms_output.put_line('Reasoning content: ' || l_content.get_clob('text'));
-           l_reasoning_message_found := true;
-         when 'text' then
-            null;
-         else
-            sys.dbms_output.put_line('Unknown content type: ' || l_content.get_string('type'));
-           ut.expect(false, 'Unknown content type in reasoning response: ' || l_content.get_string('type')).to_equal(true);
-      end case;
-    end loop assistant_content_loop;
-
-    ut.expect(l_reasoning_message_found, 'No reasoning message found in response').to_equal(true);
-
-    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
-
-  end reasoning;
-
-
-  procedure structured_output
-  as
-    l_result json_object_t;
-    l_schema json_object_t;
-    l_final_message clob;
-    l_structured_output json_object_t;
-    l_messages json_array_t;
-    l_message_count pls_integer;
-
-    l_response clob;
-    l_confidence number;
-  begin
-    uc_ai.g_base_url := 'host.containers.internal:11434/api';
-    uc_ai.g_enable_tools := false; -- disable tools for this test
-    uc_ai.g_enable_reasoning := true; -- enable reasoning for this test
-
-    l_schema := uc_ai_test_utils.get_confidence_json_schema();
-
-    l_result := uc_ai.generate_text(
-      p_user_prompt => 'What is the capital of France? Please respond with confidence.',
-      p_system_prompt => 'You are a helpful assistant that provides accurate information.',
-      p_provider => uc_ai.c_provider_ollama,
-      p_model => c_model_qwen_4b,
-      p_response_json_schema => l_schema
-    );
-
-    -- Test that we received a result
-    ut.expect(l_result).to_be_not_null();
-
-    l_final_message := l_result.get_clob('final_message');
-    sys.dbms_output.put_line('Response: ' || l_final_message);
-    
-    -- Test that we received a final message
-    ut.expect(l_final_message).to_be_not_null();
-
-    -- Test that the response is valid JSON
-    l_structured_output := json_object_t(l_final_message);
-
-    l_response := l_structured_output.get_string('response');
-    l_confidence := l_structured_output.get_number('confidence');
-
-    -- Test the response content
-    ut.expect(lower(l_response)).to_be_like('%paris%');
-
-    -- Test confidence is a number between 0 and 1
-    ut.expect(l_confidence).to_be_between(0, 1);
-
-    -- Test message structure
-    l_messages := treat(l_result.get('messages') as json_array_t);
-    l_message_count := l_messages.get_size;
-    ut.expect(l_message_count).to_equal(3); -- system, user, assistant
-
-    -- Validate message array structure against spec
-    uc_ai_test_message_utils.validate_message_array(l_messages, 'Structured Output Test');
-
-    if l_structured_output is not null then
-      sys.dbms_output.put_line('Structured Response: ' || l_structured_output.get_string('response'));
-      sys.dbms_output.put_line('Confidence: ' || l_structured_output.get_number('confidence'));
-    else
-      sys.dbms_output.put_line('No structured output received');
-    end if;
-  end structured_output;
-
   procedure embeddings
   as
     l_result json_array_t;
     l_array_clob clob;
   begin
-    uc_ai.g_base_url := 'host.containers.internal:11434/api';
-    uc_ai.g_enable_tools := false; -- disable tools for this test
-    uc_ai.g_enable_reasoning := false; -- disable reasoning for this test
+    setup_ollama;
+    uc_ai.g_enable_tools := false;
 
     l_result := uc_ai.generate_embeddings(
       p_input => json_array_t('["APEX Office Print lets you create and manage print jobs directly from your APEX applications."]'),
       p_provider => uc_ai.c_provider_ollama,
-      p_model => 'granite-embedding:30m'
+      p_model => 'qwen3-embedding:8b'
     );
-    
 
     l_array_clob := l_result.to_clob;
     ut.expect(l_array_clob).to_be_not_null();
-    sys.dbms_output.put_line('Embeddings array: ' || l_array_clob);
+    sys.dbms_output.put_line('Embeddings array: ' || substr(l_array_clob, 1, 500) || '...');
     ut.expect(l_result.get_size).to_equal(1);
     ut.expect(treat(l_result.get(0) as json_array_t).get_size).to_be_greater_than(0);
   end embeddings;
@@ -413,14 +309,13 @@ create or replace package body test_uc_ai_ollama as
     l_result json_array_t;
     l_array_clob clob;
   begin
-    uc_ai.g_base_url := 'host.containers.internal:11434/api';
+    setup_ollama;
     uc_ai.g_enable_tools := false;
-    uc_ai.g_enable_reasoning := false;
 
     l_result := uc_ai.generate_embeddings(
       p_input => json_array_t('["APEX Office Print lets you create and manage print jobs.", "Oracle Database is the world leading relational database.", "PL/SQL is a procedural extension to SQL."]'),
       p_provider => uc_ai.c_provider_ollama,
-      p_model => 'granite-embedding:30m'
+      p_model => 'qwen3-embedding:8b'
     );
 
     l_array_clob := l_result.to_clob;

--- a/test/test_uc_ai_ollama.pks
+++ b/test/test_uc_ai_ollama.pks
@@ -2,56 +2,26 @@ create or replace package test_uc_ai_ollama as
 
   --%suite(Ollama AI tests)
 
-  -- Base procedures with model parameter
-  procedure basic_recipe(
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  );
-  procedure tool_user_info(
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  );
-  procedure tool_clock_in_user(
-    p_model in uc_ai.model_type,
-    p_base_url in varchar2 default 'host.containers.internal:11434/api',
-    p_reasoning_enabled in boolean default true
-  );
+  --%test(Basic recipe assistant)
+  procedure basic_recipe;
 
-  -- Test procedures for specific models
-  --%test(Basic recipe assistant - Qwen 1.7b)
-  procedure basic_recipe_qwen_1b;
+  --%test(Tool usage - get user info)
+  procedure tool_user_info;
 
-  --%test(Basic recipe assistant - Gemma3 4b)
-  procedure basic_recipe_gemma_4b;
+  --%test(Tool usage - clock in user)
+  procedure tool_clock_in_user;
 
-  --%test(Basic recipe assistant - GPT OSS)
-  procedure basic_recipe_gpt_oss;
+  --%test(Basic recipe assistant - Responses API)
+  procedure basic_recipe_responses_api;
 
-  --%test(Tool usage - get user info - Qwen 4b)
-  procedure tool_user_info_qwen_4b;
+  --%test(Tool usage - get user info - Responses API)
+  procedure tool_user_info_responses_api;
 
-  --%test(Tool usage - get user info - GPT OSS)
-  procedure tool_user_info_gpt_oss;
-
-  --%test(Tool usage - clock in user - Qwen 4b)
-  procedure tool_clock_in_user_qwen_4b;
-
-  --%test(Tool usage - clock in user - GPT OSS)
-  procedure tool_clock_in_user_gpt_oss;
+  --%test(Tool usage - clock in user - Responses API)
+  procedure tool_clock_in_responses_api;
 
   --%test(Convert messages)
   procedure convert_messages;
-
-  --%test(image file input)
-  procedure image_file_input_gemma_4b;
-
-  --%test(reasoning)
-  procedure reasoning;
-
-  --%test(Structured output)
-  procedure structured_output;
 
   --%test(Embeddings)
   procedure embeddings;

--- a/test/test_uc_ai_openai_chat.pkb
+++ b/test/test_uc_ai_openai_chat.pkb
@@ -312,6 +312,50 @@ create or replace package body test_uc_ai_openai_chat as
   end image_file_input;
 
 
+  procedure reasoning_with_tools
+  as
+    l_result json_object_t;
+    l_final_message clob;
+    l_messages json_array_t;
+    l_message_count pls_integer;
+    l_tool_calls_count pls_integer;
+  begin
+    delete from UC_AI_TOOL_PARAMETERS where 1 = 1;
+    delete from UC_AI_TOOLS where 1 = 1;
+    uc_ai_test_utils.add_get_users_tool();
+
+    uc_ai.g_enable_tools := true;
+    uc_ai.g_enable_reasoning := true;
+    uc_ai_openai.g_reasoning_effort := 'low';
+
+    l_result := uc_ai.GENERATE_TEXT(
+      p_user_prompt => 'What is the email address of Jim?',
+      p_system_prompt => 'You are an assistant to a time tracking system. Your tools give you access to user, project and timetracking information. Answer concise and short.',
+      p_provider => uc_ai.c_provider_openai,
+      p_model => uc_ai_openai.c_model_gpt_o4_mini
+    );
+
+    sys.dbms_output.put_line('Result: ' || l_result.to_string);
+
+    l_final_message := l_result.get_clob('final_message');
+    sys.dbms_output.put_line('Last message: ' || l_final_message);
+    ut.expect(l_final_message).to_be_not_null();
+
+    l_messages := treat(l_result.get('messages') as json_array_t);
+    l_message_count := l_messages.get_size;
+    ut.expect(l_message_count).to_be_greater_than(2); -- Should have tool calls
+
+    l_tool_calls_count := l_result.get_number('tool_calls_count');
+    sys.dbms_output.put_line('Tool calls: ' || l_tool_calls_count);
+    ut.expect(l_tool_calls_count).to_be_greater_than(0);
+
+    -- Validate message array structure against spec
+    uc_ai_test_message_utils.validate_message_array(l_messages, 'Reasoning with Tools Test');
+
+    ut.expect(lower(l_messages.to_clob)).not_to_be_like('%error%');
+  end reasoning_with_tools;
+
+
   procedure reasoning
   as
     l_messages json_array_t := json_array_t();

--- a/test/test_uc_ai_openai_chat.pks
+++ b/test/test_uc_ai_openai_chat.pks
@@ -23,6 +23,9 @@ create or replace package test_uc_ai_openai_chat as
   --%test(image file input)
   procedure image_file_input;
 
+  --%test(reasoning with tools)
+  procedure reasoning_with_tools;
+
   --%test(reasoning)
   procedure reasoning;
 

--- a/test/test_uc_ai_tools_api.pkb
+++ b/test/test_uc_ai_tools_api.pkb
@@ -491,5 +491,209 @@ create or replace package body test_uc_ai_tools_api as
 
   end test_create_tool_with_tags;
 
+  /*
+   * Test that merge_tool_from_schema creates a new tool when none exists
+   */
+  procedure test_merge_tool_creates_new as
+    l_tool_id uc_ai_tools.id%type;
+    l_schema clob;
+    l_tool_count number;
+    l_param_count number;
+  begin
+    l_schema := '{
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max results"
+        }
+      },
+      "required": ["query"]
+    }';
+
+    l_tool_id := uc_ai_tools_api.merge_tool_from_schema(
+      p_tool_code => gc_test_prefix || 'MERGE_NEW',
+      p_description => 'Tool created via merge',
+      p_function_call => 'return search_function(:parameters);',
+      p_json_schema => json_object_t.parse(l_schema),
+      p_created_by => gc_test_user
+    );
+
+    ut.expect(l_tool_id).to_be_not_null();
+
+    -- Verify tool was created
+    select count(*) into l_tool_count
+    from uc_ai_tools
+    where id = l_tool_id and code = gc_test_prefix || 'MERGE_NEW';
+
+    ut.expect(l_tool_count).to_equal(1);
+
+    -- Verify parameters
+    select count(*) into l_param_count
+    from uc_ai_tool_parameters
+    where tool_id = l_tool_id;
+
+    ut.expect(l_param_count).to_equal(2);
+
+  end test_merge_tool_creates_new;
+
+  /*
+   * Test that merge_tool_from_schema updates an existing tool
+   */
+  procedure test_merge_tool_updates_existing as
+    l_tool_id_1 uc_ai_tools.id%type;
+    l_tool_id_2 uc_ai_tools.id%type;
+    l_schema clob;
+    l_description uc_ai_tools.description%type;
+    l_param_count number;
+    l_required_count number;
+  begin
+    -- Create initial tool
+    l_schema := '{
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name"
+        }
+      },
+      "required": ["name"]
+    }';
+
+    l_tool_id_1 := uc_ai_tools_api.merge_tool_from_schema(
+      p_tool_code => gc_test_prefix || 'MERGE_UPD',
+      p_description => 'Original description',
+      p_function_call => 'return original_function(:parameters);',
+      p_json_schema => json_object_t.parse(l_schema),
+      p_created_by => gc_test_user
+    );
+
+    -- Merge with updated schema and description
+    l_schema := '{
+      "type": "object",
+      "properties": {
+        "first_name": {
+          "type": "string",
+          "description": "First name"
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name"
+        },
+        "age": {
+          "type": "integer",
+          "description": "Age"
+        }
+      },
+      "required": ["first_name", "last_name"]
+    }';
+
+    l_tool_id_2 := uc_ai_tools_api.merge_tool_from_schema(
+      p_tool_code => gc_test_prefix || 'MERGE_UPD',
+      p_description => 'Updated description',
+      p_function_call => 'return updated_function(:parameters);',
+      p_json_schema => json_object_t.parse(l_schema),
+      p_created_by => gc_test_user
+    );
+
+    -- Should return the same tool ID
+    ut.expect(l_tool_id_2).to_equal(l_tool_id_1);
+
+    -- Verify description was updated
+    select description into l_description
+    from uc_ai_tools
+    where id = l_tool_id_2;
+
+    ut.expect(l_description).to_equal('Updated description');
+
+    -- Verify old parameters were replaced with new ones
+    select count(*) into l_param_count
+    from uc_ai_tool_parameters
+    where tool_id = l_tool_id_2;
+
+    ut.expect(l_param_count).to_equal(3);
+
+    -- Verify new required parameters
+    select count(*) into l_required_count
+    from uc_ai_tool_parameters
+    where tool_id = l_tool_id_2 and required = 1;
+
+    ut.expect(l_required_count).to_equal(2);
+
+  end test_merge_tool_updates_existing;
+
+  /*
+   * Test that merge_tool_from_schema replaces tags on update
+   */
+  procedure test_merge_tool_replaces_tags as
+    l_tool_id uc_ai_tools.id%type;
+    l_schema clob;
+    l_tag_count number;
+    l_has_new_tag number;
+  begin
+    l_schema := '{
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "A value"
+        }
+      }
+    }';
+
+    -- Create tool with initial tags
+    l_tool_id := uc_ai_tools_api.merge_tool_from_schema(
+      p_tool_code => gc_test_prefix || 'MERGE_TAGS',
+      p_description => 'Tool with tags',
+      p_function_call => 'return tag_function(:parameters);',
+      p_json_schema => json_object_t.parse(l_schema),
+      p_created_by => gc_test_user,
+      p_tags => apex_t_varchar2('old-tag-1', 'old-tag-2')
+    );
+
+    -- Verify initial tags
+    select count(*) into l_tag_count
+    from uc_ai_tool_tags
+    where tool_id = l_tool_id;
+
+    ut.expect(l_tag_count).to_equal(2);
+
+    -- Merge with new tags
+    l_tool_id := uc_ai_tools_api.merge_tool_from_schema(
+      p_tool_code => gc_test_prefix || 'MERGE_TAGS',
+      p_description => 'Tool with tags',
+      p_function_call => 'return tag_function(:parameters);',
+      p_json_schema => json_object_t.parse(l_schema),
+      p_created_by => gc_test_user,
+      p_tags => apex_t_varchar2('new-tag-1', 'new-tag-2', 'new-tag-3')
+    );
+
+    -- Verify tags were replaced
+    select count(*) into l_tag_count
+    from uc_ai_tool_tags
+    where tool_id = l_tool_id;
+
+    ut.expect(l_tag_count).to_equal(3);
+
+    -- Verify old tags are gone
+    select count(*) into l_has_new_tag
+    from uc_ai_tool_tags
+    where tool_id = l_tool_id and tag_name = 'old-tag-1';
+
+    ut.expect(l_has_new_tag).to_equal(0);
+
+    -- Verify new tags exist
+    select count(*) into l_has_new_tag
+    from uc_ai_tool_tags
+    where tool_id = l_tool_id and tag_name = 'new-tag-1';
+
+    ut.expect(l_has_new_tag).to_equal(1);
+
+  end test_merge_tool_replaces_tags;
+
 end test_uc_ai_tools_api;
 /

--- a/test/test_uc_ai_tools_api.pks
+++ b/test/test_uc_ai_tools_api.pks
@@ -26,7 +26,14 @@ create or replace package test_uc_ai_tools_api as
   --%test(Create tool with tags)
   procedure test_create_tool_with_tags;
 
+  --%test(Merge tool creates new tool when none exists)
+  procedure test_merge_tool_creates_new;
 
+  --%test(Merge tool updates existing tool)
+  procedure test_merge_tool_updates_existing;
+
+  --%test(Merge tool replaces tags on update)
+  procedure test_merge_tool_replaces_tags;
 
 end test_uc_ai_tools_api;
 /

--- a/test/uc_ai_test_message_utils.pkb
+++ b/test/uc_ai_test_message_utils.pkb
@@ -352,10 +352,18 @@ create or replace package body uc_ai_test_message_utils as
     ut.expect(not p_response.get('model').is_null, 
              p_test_name || ': Return object model field should not be null').to_be_true();
 
-    validate_usage_object(
-      p_usage => treat(p_response.get('usage') as json_object_t),
-      p_test_name => p_test_name || ' - Usage Object Validation'
-    );
+    ut.expect(p_response.has('usage'),
+             p_test_name || ': Return object should have usage field').to_be_true();
+
+    if p_response.has('usage') then
+      ut.expect(not p_response.get('usage').is_null,
+               p_test_name || ': Return object usage field should not be null').to_be_true();
+
+      validate_usage_object(
+        p_usage => treat(p_response.get('usage') as json_object_t),
+        p_test_name => p_test_name || ' - Usage Object Validation'
+      );
+    end if;
 
     validate_message_array(
       p_messages => treat(p_response.get('messages') as json_array_t),


### PR DESCRIPTION
create_tool_from_schema now updates existing tools instead of failing on unique constraint.

Problem:
When calling create_tool_from_schema with an existing tool code, it failed with:
`ORA-00001: unique constraint (KS.UC_AI_TOOLS_UK) violated on table KS.UC_AI_TOOLS columns (CODE)`

Solution:

Check if tool with same code exists before insert
If exists: update the tool record, delete and recreate parameters and tags
If not exists: create new tool as before
Use Case:
Users may call uc_ai_tools_api.create_tool_from_schema multiple times to quickly update parameter values, tool instructions, or other tool configuration without needing to manually delete the tool first.

Changes:

uc_ai_tools_api.pkb: Added upsert logic to create_tool_from_schema
uc_ai_tools_api.pks: Updated documentation to reflect new behavior
